### PR TITLE
ci: Install package dev dependencies prior to running pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
-      - uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --hook-stage manual --all-files
       - name: Run Pylint
         run: uvx nox -s pylint -- --output-format=github
 
@@ -44,11 +41,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
         runs-on: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
 
         include:
-          - python-version: "pypy-3.11"
+          - python-version: "pypy-3.12"
             runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Closes #13

Also updates the `python-version` matrix to run tests on 3.12 / 3.13 / 3.14