### PR TITLE
ci(tests): Add workflow to run pytest

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# TopoStats Pull Requests
+# LayOpt Pull Requests
 
 Please provide a descriptive summary of the changes your Pull Request introduces.
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,57 @@
+name: Tests (pytest)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+    paths:
+      - "**.csv"
+      - "**.npy"
+      - "**.out"
+      - "**.pkl"
+      - "**.png"
+      - "**.py"
+      - "**.toml"
+      - "**.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v7
+      - name: Upgrade pip and install test dependencies
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install --group dev
+      - name: Test with pytest
+        run: |
+          source .venv/bin/activate
+          pytest --cov=src --numprocesses=logical
+      - name: Determine coverage
+        run: |
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
   "pytest >=9",
   "pytest-cov >=7",
   "pytest-testmon",
+  "pytest-xdist",
   "syrupy"
 ]
 dev = [


### PR DESCRIPTION
Closes #8

- Uses `uv` too setup a virtualenv and install the `--group dev` dependencies.
- Adds [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/stable/distribution.html) to test dependencies so tests
  can run in parallel.
- Includes [action-tmate](https://github.com/mxschmitt/action-tmate) for debugging if/when things fail.

Also...

- Corrects title of pull-request template.

---

Before submitting a Pull Request please check the following.

- [ ] ~Existing tests pass.~
- [ ] ~Documentation has been updated and builds.~
- [X] Pre-commit checks pass.
- [ ] ~New functions/methods have typehints and docstrings.~
- [ ] ~New functions/methods have tests which check the intended behaviour is correct.~