### PR TITLE
docs(api): includes all API docstrings

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -17,5 +17,12 @@ ignores:
   - "paper.md"
   - ".venv/"
   - ".github/CONTRIBUTING.md"
+  - "docs/api/config.md"
+  - "docs/api/entry_point.md"
+  - "docs/api/io.md"
+  - "docs/api/layopt.md"
+  - "docs/api/logging.md"
+  - "docs/api/run_modules.md"
+  - "docs/api/validation.md"
 
 fix: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,7 +108,7 @@ repos:
     rev: v0.22.0
     hooks:
       - id: markdownlint-cli2
-        args: []
+        args: ["--config .markdownlint-cli2.yaml"]
 
   - repo: https://github.com/numpy/numpydoc
     rev: v1.10.0

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,1 +1,0 @@
-# ::: layopt.example

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,0 +1,8 @@
+# Config
+
+::: layopt.config
+    handler: python
+    options:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/entry_point.md
+++ b/docs/api/entry_point.md
@@ -1,0 +1,8 @@
+# Entry Point
+
+::: layopt.entry_point
+    handler: python
+    options.extra:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,9 @@
+# API
+
+- [`config`](config.md)
+- [`entry_point`](entry_point.md)
+- [`io`](io.md)
+- [`layopt`](layopt.md)
+- [`logging`](logging.md)
+- [`run_modules`](run_modules.md)
+- [`validation`](validation.md)

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -1,0 +1,8 @@
+# IO
+
+::: layopt.io
+    handler: python
+    options.extra:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/layopt.md
+++ b/docs/api/layopt.md
@@ -1,0 +1,8 @@
+# Layopt
+
+::: layopt.layopt
+    handler: python
+    options.extra:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/logging.md
+++ b/docs/api/logging.md
@@ -1,0 +1,8 @@
+# Logging
+
+::: layopt.logging
+    handler: python
+    options.extra:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/run_modules.md
+++ b/docs/api/run_modules.md
@@ -1,0 +1,8 @@
+# Run Modules
+
+::: layopt.run_modules
+    handler: python
+    options.extra:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -1,0 +1,8 @@
+# Validation
+
+::: layopt.validation
+    handler: python
+    options.extra:
+        docstring_style: numpy
+        rendering:
+            show_signature_annotations: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,17 +35,21 @@ plugins:
   mkdocstrings:
     handlers:
       python:
-        paths: [.]
+        paths: [src]
         inventories:
           - https://docs.python.org/3/objects.inv
           - https://docs.pydantic.dev/latest/objects.inv
         options:
+          docstrings_style: numpy
+          docstring_section_style: table
+          filters: ["!^_"]
           members_order: source
           separate_signature: true
-          filters: ["!^_"]
-          show_root_heading: true
-          show_if_no_docstring: true
-          show_signature_annotations: true
+          show_if_no_docstring: false
+          show_root_full_path: false
+          show_root_heading: false
+          show_signature_annotations: false
+          show_source: true
   search: {}
 
 markdown_extensions:
@@ -66,4 +70,16 @@ nav:
   - Installation: installation.md
   - Contributing: contributing.md
   - Usage: usage.md
-  - Python API: api.md
+  - Python API:
+      - API: api/index.md
+      - config: api/config.md
+      - entry_point: api/entry_point.md
+      - io: api/io.md
+      - layopt: api/layopt.md
+      - logging: api/logging.md
+      - run_modules: api/run_modules.md
+      - validation: api/validation.md
+
+watch:
+  - docs/
+  - src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ docs = [
   "mdx-include>=1.4.2",
   "mkdocs-material>=9.1.19",
   "mkdocs-mermaid2-plugin",
-  "mkdocs>=1.1.2",
+  "mkdocs>=1.1.2,<=1.6",
   "mkdocstrings-python>=1.18.2",
   "pyyaml>=6.0.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -806,7 +806,7 @@ dev = [
     { name = "ipdb" },
     { name = "markdown", specifier = ">=3.9" },
     { name = "mdx-include", specifier = ">=1.4.2" },
-    { name = "mkdocs", specifier = ">=1.1.2" },
+    { name = "mkdocs", specifier = ">=1.1.2,<=1.6" },
     { name = "mkdocs-material", specifier = ">=9.1.19" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings-python", specifier = ">=1.18.2" },
@@ -829,7 +829,7 @@ dev = [
 docs = [
     { name = "markdown", specifier = ">=3.9" },
     { name = "mdx-include", specifier = ">=1.4.2" },
-    { name = "mkdocs", specifier = ">=1.1.2" },
+    { name = "mkdocs", specifier = ">=1.1.2,<=1.6" },
     { name = "mkdocs-material", specifier = ">=9.1.19" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings-python", specifier = ">=1.18.2" },
@@ -1089,7 +1089,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs"
-version = "1.6.1"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1106,9 +1106,9 @@ dependencies = [
     { name = "pyyaml-env-tag" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/6b/26b33cc8ad54e8bc0345cddc061c2c5c23e364de0ecd97969df23f95a673/mkdocs-1.6.0.tar.gz", hash = "sha256:a73f735824ef83a4f3bcb7a231dcab23f5a838f88b7efc54a0eef5fbdbc3c512", size = 3888392, upload-time = "2024-04-20T17:55:45.205Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c0/930dcf5a3e96b9c8e7ad15502603fc61d495479699e2d2c381e3d37294d1/mkdocs-1.6.0-py3-none-any.whl", hash = "sha256:1eb5cb7676b7d89323e62b56235010216319217d4af5ddc543a91beb8d125ea7", size = 3862264, upload-time = "2024-04-20T17:55:42.126Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Expands and builds API references.

`markdownlint-cli2` doesn't appear to be respecting the `ignore:` directive and tries to reformat each of the `docs/api/*.md` and reformat the  which is annoying and I've not yet worked out why but have to get on with other work.
