### PR TITLE
chore: update mkdocs versions

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,8 +1,10 @@
 # Config
 
+<!-- markdownlint-disable -->
 ::: layopt.config
     handler: python
     options:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+<!-- markdownlint-restore -->

--- a/docs/api/entry_point.md
+++ b/docs/api/entry_point.md
@@ -1,8 +1,10 @@
 # Entry Point
 
+<!-- markdownlint-disable -->
 ::: layopt.entry_point
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+<!-- markdownlint-restore -->

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -1,8 +1,10 @@
 # IO
 
+<!-- markdownlint-disable -->
 ::: layopt.io
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+<!-- markdownlint-restore -->

--- a/docs/api/layopt.md
+++ b/docs/api/layopt.md
@@ -1,8 +1,10 @@
 # Layopt
 
+<!-- markdownlint-disable -->
 ::: layopt.layopt
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+<!-- markdownlint-restore -->

--- a/docs/api/logging.md
+++ b/docs/api/logging.md
@@ -1,8 +1,10 @@
 # Logging
 
+<!-- markdownlint-disable -->
 ::: layopt.logging
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+<!-- markdownlint-restore -->

--- a/docs/api/run_modules.md
+++ b/docs/api/run_modules.md
@@ -1,8 +1,10 @@
 # Run Modules
 
+<!-- markdownlint-disable -->
 ::: layopt.run_modules
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+<!-- markdownlint-restore -->

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -1,8 +1,10 @@
 # Validation
 
+<!-- markdownlint-disable -->
 ::: layopt.validation
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+<!-- markdownlint-restore -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,10 @@ dev = [
 docs = [
   "markdown>=3.9",
   "mdx-include>=1.4.2",
-  "mkdocs-material>=9.1.19",
+  "mkdocs-material>=9.7.6",
   "mkdocs-mermaid2-plugin",
-  "mkdocs>=1.1.2,<=1.6",
-  "mkdocstrings-python>=1.18.2",
+  "mkdocs>=1.6.1,<=2.0.0",
+  "mkdocstrings-python>=2.0.3",
   "pyyaml>=6.0.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -806,10 +806,10 @@ dev = [
     { name = "ipdb" },
     { name = "markdown", specifier = ">=3.9" },
     { name = "mdx-include", specifier = ">=1.4.2" },
-    { name = "mkdocs", specifier = ">=1.1.2,<=1.6" },
-    { name = "mkdocs-material", specifier = ">=9.1.19" },
+    { name = "mkdocs", specifier = ">=1.6.1,<=2.0.0" },
+    { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocs-mermaid2-plugin" },
-    { name = "mkdocstrings-python", specifier = ">=1.18.2" },
+    { name = "mkdocstrings-python", specifier = ">=2.0.3" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pydocstyle", extras = ["toml"] },
@@ -829,10 +829,10 @@ dev = [
 docs = [
     { name = "markdown", specifier = ">=3.9" },
     { name = "mdx-include", specifier = ">=1.4.2" },
-    { name = "mkdocs", specifier = ">=1.1.2,<=1.6" },
-    { name = "mkdocs-material", specifier = ">=9.1.19" },
+    { name = "mkdocs", specifier = ">=1.6.1,<=2.0.0" },
+    { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocs-mermaid2-plugin" },
-    { name = "mkdocstrings-python", specifier = ">=1.18.2" },
+    { name = "mkdocstrings-python", specifier = ">=2.0.3" },
     { name = "pyyaml", specifier = ">=6.0.1" },
 ]
 test = [
@@ -1089,7 +1089,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs"
-version = "1.6.0"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1106,9 +1106,9 @@ dependencies = [
     { name = "pyyaml-env-tag" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/6b/26b33cc8ad54e8bc0345cddc061c2c5c23e364de0ecd97969df23f95a673/mkdocs-1.6.0.tar.gz", hash = "sha256:a73f735824ef83a4f3bcb7a231dcab23f5a838f88b7efc54a0eef5fbdbc3c512", size = 3888392, upload-time = "2024-04-20T17:55:45.205Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/c0/930dcf5a3e96b9c8e7ad15502603fc61d495479699e2d2c381e3d37294d1/mkdocs-1.6.0-py3-none-any.whl", hash = "sha256:1eb5cb7676b7d89323e62b56235010216319217d4af5ddc543a91beb8d125ea7", size = 3862264, upload-time = "2024-04-20T17:55:42.126Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
 ]
 
 [[package]]
@@ -1141,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.4"
+version = "9.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -1156,9 +1156,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/ce/a1cd02ac7448763f0bb56aaf5f23fa2527944ac6df335080c38c2f253165/mkdocs_material-9.7.4.tar.gz", hash = "sha256:711b0ee63aca9a8c7124d4c73e83a25aa996e27e814767c3a3967df1b9e56f32", size = 4097804, upload-time = "2026-03-03T19:57:36.827Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/94/e3535a9ed078b238df3df75a44694ca0ff5772fd538df4939c658a58c59d/mkdocs_material-9.7.4-py3-none-any.whl", hash = "sha256:6549ad95e4d130ed5099759dfa76ea34c593eefdb9c18c97273605518e99cfbf", size = 9305224, upload-time = "2026-03-03T19:57:34.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Builds failed on CI, I found locally that updating `mkdocs` and `mkdocs-material` solved this so have bumped the versions in `pyproject.toml` and updated `uv.lock`.

Also attempt to explicitly ignore `docs/api/*.md` by using fences to disable `markdownlint-cli2` around regions that are getting reformatted.