### PR TITLE
ci: mkdocs-get-deps update; mkdocs under Python 3.13

### DIFF
--- a/.github/workflows/build_mkdocs.yaml
+++ b/.github/workflows/build_mkdocs.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           activate-environment: true
-          python-version: 3.14
+          python-version: 3.13
       - name: Install package dependencies
         run: |
           uv sync --locked --all-extras --dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dev = [
 docs = [
   "markdown>=3.9",
   "mdx-include>=1.4.2",
+  "mkdocs-get-deps>=0.2.2",
   "mkdocs-material>=9.7.6",
   "mkdocs-mermaid2-plugin",
   "mkdocs>=1.6.1,<=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -745,6 +745,7 @@ dev = [
     { name = "markdown" },
     { name = "mdx-include" },
     { name = "mkdocs" },
+    { name = "mkdocs-get-deps" },
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings-python" },
@@ -768,6 +769,7 @@ docs = [
     { name = "markdown" },
     { name = "mdx-include" },
     { name = "mkdocs" },
+    { name = "mkdocs-get-deps" },
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings-python" },
@@ -807,6 +809,7 @@ dev = [
     { name = "markdown", specifier = ">=3.9" },
     { name = "mdx-include", specifier = ">=1.4.2" },
     { name = "mkdocs", specifier = ">=1.6.1,<=2.0.0" },
+    { name = "mkdocs-get-deps", specifier = ">=0.2.2" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings-python", specifier = ">=2.0.3" },
@@ -830,6 +833,7 @@ docs = [
     { name = "markdown", specifier = ">=3.9" },
     { name = "mdx-include", specifier = ">=1.4.2" },
     { name = "mkdocs", specifier = ">=1.6.1,<=2.0.0" },
+    { name = "mkdocs-get-deps", specifier = ">=0.2.2" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings-python", specifier = ">=2.0.3" },
@@ -1127,16 +1131,16 @@ wheels = [
 
 [[package]]
 name = "mkdocs-get-deps"
-version = "0.2.0"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mergedeep" },
     { name = "platformdirs" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Building docs still failing on CI. Might fix...

- Explicitly set the minimum version for `mkdocs-get-deps>=0.2.2` as it was one of the differences between local and CI.
- Set the Python version to build under 3.13.
