### PR TITLE
chore: add docs/api to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Let markdownlint-cli2 handle all .md linting
+**/*.md

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,10 +1,12 @@
 # Config
 
 <!-- markdownlint-disable -->
+
 ::: layopt.config
     handler: python
     options:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+
 <!-- markdownlint-restore -->

--- a/docs/api/entry_point.md
+++ b/docs/api/entry_point.md
@@ -1,10 +1,12 @@
 # Entry Point
 
 <!-- markdownlint-disable -->
+
 ::: layopt.entry_point
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+
 <!-- markdownlint-restore -->

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -1,10 +1,12 @@
 # IO
 
 <!-- markdownlint-disable -->
+
 ::: layopt.io
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+
 <!-- markdownlint-restore -->

--- a/docs/api/layopt.md
+++ b/docs/api/layopt.md
@@ -1,10 +1,12 @@
 # Layopt
 
 <!-- markdownlint-disable -->
+
 ::: layopt.layopt
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+
 <!-- markdownlint-restore -->

--- a/docs/api/logging.md
+++ b/docs/api/logging.md
@@ -1,10 +1,12 @@
 # Logging
 
 <!-- markdownlint-disable -->
+
 ::: layopt.logging
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+
 <!-- markdownlint-restore -->

--- a/docs/api/run_modules.md
+++ b/docs/api/run_modules.md
@@ -1,10 +1,12 @@
 # Run Modules
 
 <!-- markdownlint-disable -->
+
 ::: layopt.run_modules
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+
 <!-- markdownlint-restore -->

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -1,10 +1,12 @@
 # Validation
 
 <!-- markdownlint-disable -->
+
 ::: layopt.validation
     handler: python
     options.extra:
         docstring_style: numpy
         rendering:
             show_signature_annotations: true
+
 <!-- markdownlint-restore -->


### PR DESCRIPTION
I was barking up the wrong tree, it is [prettier](https://prettier.io/docs/ignore/) that needed to ignore files.

Have opted to configure it to ignore _all_ `**/*.md` and leave formatting of Markdown to [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
