### PR TITLE
fix(run_modules): open user config before yaml.full_load()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "pandas",
   "pandas-stubs",
   "pydantic",
+  "ruamel.yaml",
   "schema",
   "scipy",
   "shapely",

--- a/src/layopt/io.py
+++ b/src/layopt/io.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from pkgutil import get_data
 from typing import Any
 
+import numpy as np
 import pandas as pd
+import ruamel.yaml
 import yaml
 from loguru import logger
 from yaml import YAMLError
@@ -32,6 +34,11 @@ def write_config(args: Namespace | dict[str, Any] | None) -> None:
     if isinstance(args, Namespace):
         output_dir = Path("./") if args.output_dir is None else Path(args.output_dir)
         filename = "default_config.yaml" if args.filename is None else args.filename
+        try:
+            config = get_data(package="layopt", resource="default_config.yaml")
+        except FileNotFoundError as exc:
+            msg = "There was a problem loading 'default_config.yaml' try reinstalling LayOpt."
+            raise (FileNotFoundError(msg)) from exc
     # Otherwise we are writing after 'layopt optimise' and config is a dictionary, this won't have a 'filename'
     # key/value pair
     elif isinstance(args, dict):
@@ -40,6 +47,7 @@ def write_config(args: Namespace | dict[str, Any] | None) -> None:
         )
         # Add missing 'filename' key/value pair
         filename = f"config_{get_date_time(strftime='%Y-%m-%d-%H%M%S')}.yaml"
+        config = args
     else:
         msg = f"args is neither 'Namespace' or 'dict' : {type(args)}"
         raise TypeError(msg)
@@ -48,21 +56,56 @@ def write_config(args: Namespace | dict[str, Any] | None) -> None:
     else:
         config_path = output_dir / filename
     logger_msg = "A sample configuration has been written to"
-    try:
-        config = get_data(package="layopt", resource="default_config.yaml")
-    except FileNotFoundError as exc:
-        msg = (
-            "There was a problem loading 'default_config.yaml' try reinstalling LayOpt."
-        )
-        raise (FileNotFoundError(msg)) from exc
     with config_path.open("w", encoding="utf-8") as f:
         try:
             f.write(f"# Config generated {get_date_time()}\n")
             f.write(f"{CONFIG_DOCUMENTATION_REFERENCE}")
-            f.write(config.decode("utf-8"))
+            yaml_out = ruamel.yaml.YAML()
+            yaml_out.indent(sequence=4, offset=2)
+            yaml_out.dump(dict_to_yaml(config), f)
         except:  # noqa: E722, pylint: disable=W0702
             logger.error(f"Failed to write config to : {config_path}")
     logger.info(f"{logger_msg} : {config_path!s}")
+
+
+def dict_to_yaml(obj: Any) -> Any:
+    """
+    Clean a dictionary to basic data types for writing to YAML.
+
+    Parameters
+    ----------
+    obj : Any
+        An object for converting to basic data types.
+
+    Returns
+    -------
+    Any
+        ``obj`` as ``str``, ``int``, ``float``, ``bool``, ``list`` or ``dict``.
+    """
+    # Recurse on dictionaries
+    if isinstance(obj, dict):
+        new = {}
+        for k, v in obj.items():
+            key = k if isinstance(k, str) else str(k)
+            new[key] = dict_to_yaml(v)
+        return new
+    # Recurse on lists and tuples
+    if isinstance(obj, (list, tuple)):
+        return [dict_to_yaml(x) for x in obj]
+    # Safe types return as is
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+    # Convert Path -> string
+    if isinstance(obj, Path):
+        return str(obj)
+    # Convert numpy array -> nested lists
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    # Convert numpy scalar -> native Python scalar
+    if isinstance(obj, np.generic):
+        return obj.item()
+    # If nothing else is matched use string representation
+    return str(obj)
 
 
 def read_yaml(filename: str | Path) -> dict[str, Any]:

--- a/src/layopt/run_modules.py
+++ b/src/layopt/run_modules.py
@@ -137,16 +137,18 @@ def optimise(args: argparse.Namespace | None = None) -> None:
         # save_to_csv=_config["save_to_csv"],
         notes=_config["notes"],
     )
-    _config["filter_levels"] = [0.001, 0.01, 0.1]
-    # Run processing in parallel
+    # ns-rse 2026-04-24 : currently run in parallel over filter_levels so need at least one value
+    filter_levels = (
+        [1.0] if len(_config["filter_levels"]) == 0 else _config["filter_levels"]
+    )  # Run processing in parallel
     with Pool(processes=_config["cores"]) as pool:
         all_results = defaultdict()
         with tqdm(
-            total=len(_config["filter_levels"]),
+            total=len(filter_levels),
             desc=f"Solving optimisation results are under '{_config['output_dir']}'.",
         ) as pbar:
             for _, _, result, filter_level in pool.imap_unordered(
-                processing_function, _config["filter_levels"]
+                processing_function, filter_levels
             ):
                 if result is not None:
                     all_results[filter_level] = result

--- a/src/layopt/run_modules.py
+++ b/src/layopt/run_modules.py
@@ -86,7 +86,8 @@ def _parse_configuration(args: argparse.Namespace | None = None) -> dict[str, An
         default_config = yaml.full_load(default_config)
     else:
         logger.info(f"Loading configuration from : {args.config_file!s}")
-        default_config = yaml.full_load(args.config_file)
+        with args.config_file.open(encoding="utf-8") as conf:
+            default_config = yaml.full_load(conf)
     _config = config.reconcile_config_args(args=args, default_config=default_config)
     # Validate configuration
     logger.debug(f"Configuration prior to validation :\n{pformat(_config, indent=4)}")
@@ -142,7 +143,7 @@ def optimise(args: argparse.Namespace | None = None) -> None:
         all_results = defaultdict()
         with tqdm(
             total=len(_config["filter_levels"]),
-            desc=f"Solving optimisation for {len(_config['filter_levels'])}, results are under {_config['output_dir']}.",
+            desc=f"Solving optimisation results are under '{_config['output_dir']}'.",
         ) as pbar:
             for _, _, result, filter_level in pool.imap_unordered(
                 processing_function, _config["filter_levels"]

--- a/uv.lock
+++ b/uv.lock
@@ -730,6 +730,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pandas-stubs" },
     { name = "pydantic" },
+    { name = "ruamel-yaml" },
     { name = "schema" },
     { name = "scipy" },
     { name = "shapely" },
@@ -794,6 +795,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pandas-stubs" },
     { name = "pydantic" },
+    { name = "ruamel-yaml" },
     { name = "schema" },
     { name = "scipy" },
     { name = "shapely" },
@@ -1982,6 +1984,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I hadn't tested this before but found today whilst trying to run some plotting with different configurations that the YAML file was passed as `Path`. It needs opening first so that the _contents_ can be passed to `yaml.full_load()`.


---

- [X] Existing tests pass.
- [ ] ~Documentation has been updated and builds.~
- [X] Pre-commit checks pass (bar `mypy`!)
- [ ] ~New functions/methods have typehints and docstrings.~
- [ ] ~New functions/methods have tests which check the intended behaviour is correct.~
