### PR TITLE
fix(validation): many Schema values now correctly check if `int` or `float`

### DIFF
--- a/src/layopt/validation.py
+++ b/src/layopt/validation.py
@@ -61,18 +61,18 @@ LAYOPT_CONFIG_SCHEMA = Schema(
         "width": lambda n: n >= 1,
         "height": lambda n: n >= 1,
         "stress_tensile": Or(
-            And(int, lambda n: n > 0.0),
+            And(int, lambda n: n >= 0.0),
             And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'stress_tensile', valid values are >= 0.0.",
         ),
         "stress_compressive": Or(
-            And(int, lambda n: n > 0.0),
+            And(int, lambda n: n >= 0.0),
             And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'stress_compressive', valid values are >= 0.0.",
         ),
-        "joint_cost": And(
-            float,
-            lambda n: n >= 0.0,
+        "joint_cost": Or(
+            And(int, lambda n: n >= 0.0),
+            And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'joint_cost', valid values are >= 0.0",
         ),
         "loaded_points": And(
@@ -85,19 +85,19 @@ LAYOPT_CONFIG_SCHEMA = Schema(
             lambda n: len(n) == 2,
             error="❌ Invalid value in config for 'load_direction', should be a tuple of length 2.",
         ),
-        "load_large": And(
-            float,
-            lambda n: n >= 0.0,
+        "load_large": Or(
+            And(int, lambda n: n >= 0.0),
+            And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'load_large', valid values are >= 0.0.",
         ),
-        "load_small": And(
-            float,
-            lambda n: n >= 0.0,
+        "load_small": Or(
+            And(int, lambda n: n >= 0.0),
+            And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'load_small', valid values are >= 0.0.",
         ),
-        "max_length": And(
-            float,
-            lambda n: n >= 0.0,
+        "max_length": Or(
+            And(int, lambda n: n >= 0.0),
+            And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'max_length', valid values are >= 0.0.",
         ),
         "support_points": And(
@@ -139,7 +139,7 @@ LAYOPT_CONFIG_SCHEMA = Schema(
             "dpi": And(
                 int,
                 lambda n: n >= 100,
-                error="❌ Invalid value for 'plotting.dpi', should be a float > 0.0.",
+                error="❌ Invalid value for 'plotting.dpi', should be an int >= 100.",
             ),
         },
     }

--- a/src/layopt/validation.py
+++ b/src/layopt/validation.py
@@ -61,17 +61,17 @@ LAYOPT_CONFIG_SCHEMA = Schema(
         "width": lambda n: n >= 1,
         "height": lambda n: n >= 1,
         "stress_tensile": Or(
-            And(int, lambda n: n >= 0.0),
+            And(int, lambda n: n >= 0),
             And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'stress_tensile', valid values are >= 0.0.",
         ),
         "stress_compressive": Or(
-            And(int, lambda n: n >= 0.0),
+            And(int, lambda n: n >= 0),
             And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'stress_compressive', valid values are >= 0.0.",
         ),
         "joint_cost": Or(
-            And(int, lambda n: n >= 0.0),
+            And(int, lambda n: n >= 0),
             And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'joint_cost', valid values are >= 0.0",
         ),
@@ -86,17 +86,17 @@ LAYOPT_CONFIG_SCHEMA = Schema(
             error="❌ Invalid value in config for 'load_direction', should be a tuple of length 2.",
         ),
         "load_large": Or(
-            And(int, lambda n: n >= 0.0),
+            And(int, lambda n: n >= 0),
             And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'load_large', valid values are >= 0.0.",
         ),
         "load_small": Or(
-            And(int, lambda n: n >= 0.0),
+            And(int, lambda n: n >= 0),
             And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'load_small', valid values are >= 0.0.",
         ),
         "max_length": Or(
-            And(int, lambda n: n >= 0.0),
+            And(int, lambda n: n >= 0),
             And(float, lambda n: n >= 0.0),
             error="❌ Invalid value in config for 'max_length', valid values are >= 0.0.",
         ),

--- a/src/layopt/validation.py
+++ b/src/layopt/validation.py
@@ -58,8 +58,16 @@ LAYOPT_CONFIG_SCHEMA = Schema(
             error="❌ Invalid value in config for 'log_level', valid values are 'info' (default), 'debug', 'error' or 'warning",
         ),
         "cores": lambda n: 1 <= n <= os.cpu_count(),
-        "width": lambda n: n >= 1,
-        "height": lambda n: n >= 1,
+        "width": And(
+            int,
+            lambda n: n >= 1,
+            error="❌ Invalid value in config for 'width', valid values are int >= 1.",
+        ),
+        "height": And(
+            int,
+            lambda n: n >= 1,
+            error="❌ Invalid value in config for 'height', valid values are int >= 1.",
+        ),
         "stress_tensile": Or(
             And(int, lambda n: n >= 0),
             And(float, lambda n: n >= 0.0),


### PR DESCRIPTION
`stress_tensile`, `stress_compressive`, `joint_cost`, `load_large`, `load_small`, `max_length` now accept any non-negative `int` or `float` values. Previously, many of these only accepted non-negative `float`, and some would also accept _positive_ `int`.

Also fixed error message for `dpi` validation.

Branched from `ns-rse/42-unit-tests-plot-truss`.

---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [ ] ~~Documentation has been updated and builds~~.
- [x] Pre-commit checks pass (except some numpydoc-validation failures).
- [ ] ~~New functions/methods have typehints and docstrings~~.
- [ ] New functions/methods have tests which check the intended behaviour is correct (perhaps some tests should be added in `test_validation`?).
