### PR TITLE
fix: move logging of dof to correct location

### DIFF
--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -683,8 +683,7 @@ def trussopt(
     nodal_coords = np.array([[pt.x, pt.y] for pt in points if poly.intersects(pt)])
     logger.debug(f"Node coordinates :\n{nodal_coords=}")
     dof = np.ones((len(nodal_coords), 2))
-    logger.debug(f"Degrees of Freedom : {dof=}")
-
+    
     # Default load point
     if loaded_points is None:
         loaded_points = np.asarray([[width, height // 2]])
@@ -700,6 +699,7 @@ def trussopt(
                 if any((node == point).all() for point in support_points)
                 else [1, 1]
             )
+    logger.debug(f"Degrees of Freedom : {dof=}")
     dof = np.array(dof).flatten()
 
     # Generate all pattern loads

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -683,7 +683,7 @@ def trussopt(
     nodal_coords = np.array([[pt.x, pt.y] for pt in points if poly.intersects(pt)])
     logger.debug(f"Node coordinates :\n{nodal_coords=}")
     dof = np.ones((len(nodal_coords), 2))
-    
+
     # Default load point
     if loaded_points is None:
         loaded_points = np.asarray([[width, height // 2]])


### PR DESCRIPTION
One line change so that correct `dof` is output; previously it was sent to logger before the support points were set so it was incorrect in the logger.

# LayOpt Pull Requests

Please provide a descriptive summary of the changes your Pull Request introduces.

The [Contributing](https://icair-sheffield.github.io/LayOpt/contributing/) page of the website if you are unfamiliar
with linting, pre-commit, docstrings and testing.

**NB** - This header should be replaced with the description but please complete the below checklist or a short
description of why a particular item is not relevant.

---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [ ] ~~Documentation has been updated and builds.~~
- [x] Pre-commit checks pass.
- [ ] ~~New functions/methods have typehints and docstrings.~~
- [ ] New functions/methods have tests which check the intended behaviour is correct. (maybe one could be added)
