### PR TITLE
refactor(layopt): member_area_filtering() as independent function

### DIFF
--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -898,19 +898,45 @@ def trussopt(
                 logger.warning("No plot generated as volume <= 0.0")
         logger.info(f"Plotting took {time.process_time() - solve_end!s}")
 
-    # Filter output members by area threshold
-    # Build area dict where keys are ground structure member indices
-    active_indices = np.where(potential_members[:, 3])[0]
-    threshold = max(filter_areas) * parameters.member_area_filtering
-    keep = filter_areas >= threshold
-    kept_indices = active_indices[keep]
-    c_n = c_n[keep]
-    member_areas_filtered: dict[int, float] = {
-        int(idx): float(area)
-        for idx, area in zip(kept_indices, filter_areas[keep], strict=True)
-    }
+    member_areas_filtered = member_area_filtering(
+        active_indices=np.where(potential_members[:, 3])[0],
+        filter_areas=filter_areas,
+        filtering_threshold=parameters.member_area_filtering,
+    )
     logger.info(
         f"Area filtering at {parameters.member_area_filtering} ({100 * parameters.member_area_filtering}% of max): "
-        f"{int(np.sum(keep))} members retained"
+        f"{len(member_areas_filtered)} members retained"
     )
     return (vol, member_areas_filtered, dict_to_df(results))
+
+
+def member_area_filtering(
+    active_indices: npt.NDArray[np.float64],
+    filter_areas: npt.NDArray[np.float64],
+    filtering_threshold: float,
+) -> dict[int, float]:
+    """
+    Filter output members by area threshold.
+
+    Build a dictionary of areas where keys are ground structure member indices, filtering potential members for those
+    that exceed the threshold.
+
+    Parameters
+    ----------
+    active_indices : npt.NDArray[np.int]
+        Active indices to filter.
+    filter_areas : npt.NDArray[np.float64]
+        Areas to be filtered.
+    filtering_threshold : float
+        Filtering threshold.
+
+    Returns
+    -------
+    dict[int, float]
+        Dictionary of areas that exceed the threshold.
+    """
+    keep = filter_areas >= (max(filter_areas) * filtering_threshold)
+    return {
+        int(idx): float(area)
+        for idx, area in zip(active_indices[keep], filter_areas[keep], strict=True)
+    }

--- a/tests/test_layopt.py
+++ b/tests/test_layopt.py
@@ -233,6 +233,45 @@ def test_trussopt(
 
 
 @pytest.mark.parametrize(
+    ("active_indices", "filter_areas", "filtering_threshold", "expected"),
+    [
+        pytest.param(
+            np.asarray([0, 1]),
+            np.asarray([10.0, 10.0]),
+            0.1,
+            {0: 10, 1: 10},
+            id="Both areas exceed threshold",
+        ),
+        pytest.param(
+            np.asarray([0, 1]),
+            np.asarray([10.0, 0.9]),
+            0.1,
+            {0: 10},
+            id="Only first area exceeds threshold",
+        ),
+        pytest.param(
+            np.asarray([0, 1, 10, 1000]),
+            np.asarray([10.0, 0.9, 500.1, 500.2]),
+            0.1,
+            {10: 500.1, 1000: 500.2},
+            id="Last two of four exceed threshold",
+        ),
+    ],
+)
+def test_member_area_filtering(
+    active_indices: npt.NDArray[np.int8],
+    filter_areas: npt.NDArray[np.float64],
+    filtering_threshold: float,
+    expected: dict[int, np.float64],
+) -> None:
+    """Test for ``layopt.member_area_filtering()``."""
+    assert (
+        layopt.member_area_filtering(active_indices, filter_areas, filtering_threshold)
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
     (
         "loaded_points",
         "load_large",


### PR DESCRIPTION
Closes #111

Moves the code added in #109 to its own function and adds some simple tests.

Simplified the code a bit by...

- avoiding assigning to `threshold` we can use the scaled `filtering_threshold` directly in the inequality
- remove filtering `c_n` the filtered array was not used subsequently so filtering appeared redundant
- avoid assigning to `kept_indices` we can `zip()` the `active_indices[keep]` directly

---

Before submitting a Pull Request please check the following.

- [X] Existing tests pass.
- [ ] ~Documentation has been updated and builds.~
- [X] Pre-commit checks pass.
- [X] New functions/methods have typehints and docstrings.
- [X] New functions/methods have tests which check the intended behaviour is correct.