### PR TITLE
style: correcting all outstanding mypy errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,8 @@ report.exclude_also = [
 ]
 
 [tool.mypy]
-files = ["src", "tests"]
-python_version = "3.10"
+files = ["src"]
+python_version = "3.12"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]

--- a/src/layopt/config.py
+++ b/src/layopt/config.py
@@ -75,7 +75,9 @@ def reconcile_config_args(
     return dict(config)
 
 
-def merge_mappings(map1: MutableMapping, map2: MutableMapping) -> dict[str, Any]:
+def merge_mappings(
+    map1: MutableMapping[Any, Any], map2: MutableMapping[Any, Any]
+) -> dict[str, Any]:
     """
     Merge two mappings (dictionaries), with priority given to the second mapping.
 
@@ -83,9 +85,9 @@ def merge_mappings(map1: MutableMapping, map2: MutableMapping) -> dict[str, Any]
 
     Parameters
     ----------
-    map1 : MutableMapping
+    map1 : MutableMapping[Any, Any]
         First mapping to merge, with secondary priority.
-    map2 : MutableMapping
+    map2 : MutableMapping[Any, Any]
         Second mapping to merge, with primary priority.
 
     Returns
@@ -128,7 +130,9 @@ def merge_mappings(map1: MutableMapping, map2: MutableMapping) -> dict[str, Any]
     return dict(map1)
 
 
-def _convert_to_numpy_array(config: dict[str, Any], to_convert: str) -> dict[str, Any]:
+def _convert_to_numpy_array(
+    config: dict[str, Any] | MutableMapping[Any, Any], to_convert: str
+) -> dict[str, Any] | MutableMapping[Any, Any]:
     """
     Convert the specified dictionary key to ``np.asarray()``.
 
@@ -136,7 +140,7 @@ def _convert_to_numpy_array(config: dict[str, Any], to_convert: str) -> dict[str
     ----------
     config : dict[str, Any]
         Dictionary with field to be converted.
-    to_convert : str
+    to_convert : str | MutableMapping[Any, Any]
         Key for value that is to be converted to numpy array. If key doesn't exist the ``config`` is returned as is.
 
     Returns

--- a/src/layopt/io.py
+++ b/src/layopt/io.py
@@ -52,11 +52,11 @@ def write_config(args: Namespace | dict[str, Any] | Parameters | None) -> None:
         config = args
     # If we have 'Parameters' then configuration is stored as a dataclass and we again don't have 'filename' key/value pair
     elif isinstance(args, Parameters):
-        output_dir = Path("./") if args.output_dir is None else Path(args.output_dir)
+        output_dir = Path("./") if args.output_dir is None else Path(args.output_dir)  # type: ignore[redundant-expr]
         filename = f"config_{get_date_time(strftime='%Y-%m-%d-%H%M%S')}.yaml"
         config = RootModel[Parameters](args).model_dump()
     else:
-        msg = f"args is neither 'Namespace' or 'dict' : {type(args)}"
+        msg = f"args is neither 'Namespace', 'dict' or 'Parameters' : {type(args)}"
         raise TypeError(msg)
     if ".yaml" not in str(filename) and ".yml" not in str(filename):
         config_path = output_dir / f"{filename}.yaml"
@@ -168,7 +168,7 @@ def get_date_time(strftime: str = "%Y-%m-%d %H:%M:%S") -> str:
     return datetime.now(tz=datetime.now().astimezone().tzinfo).strftime(strftime)
 
 
-def dict_to_df(results: dict[float, dict[str, Any]]) -> pd.DataFrame:
+def dict_to_df(results: dict[float, dict[str, Any]]) -> Any:
     """
     Convert a dictionary of LayOpt results to Pandas DataFrame.
 

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -20,6 +20,7 @@ import itertools
 import time
 from math import ceil, gcd, isinf
 from pathlib import Path
+from typing import Any
 
 import mosek.fusion as mosek
 import numpy as np
@@ -319,7 +320,7 @@ def make_pattern_loads(
 def stop_primal_violation_residual(
     nodal_coords: npt.NDArray[np.float64],
     c_n: npt.NDArray[np.float64],
-    forces: npt.NDArray[np.float64],
+    forces: list[npt.NDArray[np.float64]],
     all_patterns: list[npt.NDArray[np.float64]],
     active_load_cases: npt.NDArray[np.int64],
     dof: npt.NDArray[np.float64],
@@ -631,7 +632,6 @@ def trussopt(
             (0, parameters.height),
         ]
     )
-    # poly = Polygon([(0, 0), (parameters.width, 0), (parameters.width, parameters.height), (0, parameters.height)])
     convex = poly.convex_hull.area == poly.area
     logger.debug(f"Domain created, convex? : {convex=}")
 
@@ -642,7 +642,7 @@ def trussopt(
     logger.debug(f"Points created : {len(points)=}")
     nodal_coords = np.array([[pt.x, pt.y] for pt in points if poly.intersects(pt)])
     logger.debug(f"Node coordinates :\n{nodal_coords=}")
-    dof = np.ones((len(nodal_coords), 2))
+    dof: npt.NDArray[Any] = np.ones((len(nodal_coords), 2))
     # ns-rse 2026-05-13 Build a list of nodes to be added to Structure where do loading and virtual_displacements come from?
     # all_nodes = [
     #     Node(coordinate=param[0], supported_dof=param[1])
@@ -650,13 +650,12 @@ def trussopt(
     # ]
 
     # Default load point
-    if parameters.loaded_points is None:
-        parameters.loaded_points = np.asarray(
-            [[parameters.width, parameters.height // 2]]
-        )
-        logger.info(
-            f"Loaded points not provided, calculated as : {parameters.loaded_points=}"
-        )
+    parameters.loaded_points = (
+        np.asarray([[parameters.width, parameters.height // 2]])
+        if parameters.loaded_points is None
+        else parameters.loaded_points
+    )
+    logger.debug(f"Loaded points are : {parameters.loaded_points=}")
     # support conditions
     for i, node in enumerate(nodal_coords):
         if parameters.support_points.size == 0:

--- a/src/layopt/plotting.py
+++ b/src/layopt/plotting.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
-from matplotlib import figure
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
 
 if TYPE_CHECKING:
     import numpy as np
@@ -26,7 +29,7 @@ def plot_truss(
     img_ext: str = ".png",
     bar_thickness: float = 0.3,
     dpi: int = 1200,
-) -> tuple[figure.Figure, figure.Axes]:
+) -> tuple[Figure, Axes]:
     """
     Visualise truss.
 
@@ -63,6 +66,7 @@ def plot_truss(
     ax.axis("off")
     ax.axis("equal")
     ax.set_title(title)
+    color: str | tuple[Any, int, Any]
     for i in [i for i in range(len(areas)) if areas[i] >= threshold]:
         # for i in [i for i in areas if i >= threshold]:
         if len(forces) > 1:  # multiple LC coloring
@@ -126,7 +130,7 @@ def plot_all_cases(
             nodal_coords=nodal_coords,
             c_n=c_n,
             areas=areas,
-            forces=[forces[k]],
+            forces=[forces[k]],  # type: ignore[call-overload]
             threshold=threshold,
             title=stress_tensile + " case " + str(k),
         )

--- a/src/layopt/run_modules.py
+++ b/src/layopt/run_modules.py
@@ -118,12 +118,16 @@ def optimise(args: argparse.Namespace | None = None) -> None:
     _config = _parse_configuration(args)
     _set_logging(log_level=_config.log_level)
     # Ensure filter_levels is a list and includes 1.0
-    filter_levels = [1.0] if len(_config.filter_levels) == 0 else _config.filter_levels
+    filter_levels = (
+        np.asarray([1.0])
+        if len(_config.filter_levels) == 0
+        else np.asarray(_config.filter_levels)
+    )
     # ns-rse 2026-04-30 : if 1.0 isn't in filter_levels we add it so we always have unfiltered results
     if 1.0 not in filter_levels:
         # if 1.0 not in filter_levels:
         filter_levels = np.append(filter_levels, 1.0)
-    _, _, results_df = layopt.trussopt(parameters=_config)
+    _, _, results_df = layopt.trussopt(parameters=_config)  # type: ignore[misc]
     # Transpose and tidy data frame and write results and configuration to disk
     results_df = results_df.T.reset_index(drop=True)
     results_df = results_df.sort_values(["filter_level"])


### PR DESCRIPTION
Closes #32

Fixing almost all outstanding `mypy` typing errors.

There are a few where I have used the `# type: ignore[<rule>]` as I couldn't work out how to resolve things but this
should mean that `mypy` passes both locally and in `pre-commit.ci` and so going forward we can stay on top of the
type-hints and ensure things always pass.

Explicitly exclude `tests/` from type checking.

---

Before submitting a Pull Request please check the following.

- [X] Existing tests pass.
- [X] Documentation has been updated and builds.
- [X] Pre-commit checks pass.
- [X] New functions/methods have typehints and docstrings.
- [X] New functions/methods have tests which check the intended behaviour is correct.