### PR TITLE
Refactor functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ docs = [
 
 [tool.pytest]
 minversion = "9.0"
-addopts = ["-ra", "--showlocals", "--mpl"]
+addopts = ["-ra", "--showlocals", "--mpl", "--cov"]
 strict = true
 filterwarnings = [
   "error",

--- a/src/layopt/default_config.yaml
+++ b/src/layopt/default_config.yaml
@@ -4,6 +4,7 @@ log_level: info # Verbosity used in logging
 cores: 2 # Number of cores to use when processing
 width: 3 # Width of structure
 height: 6 # Height of structure
+steps: 1 # Steps to generate nodes
 stress_tensile: 1.0 # Tensile stress
 stress_compressive: 1.0 # Compressive stress
 joint_cost: 0.0 # Joint costs

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -20,7 +20,6 @@ import itertools
 import time
 from math import ceil, gcd, isinf
 from pathlib import Path
-from typing import Any
 
 import mosek.fusion as mosek
 import numpy as np

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -602,6 +602,38 @@ def stop_primal_violation_pattern(
     return True  # converged, terminate
 
 
+def _support_conditions(
+    nodal_coords: npt.NDArray[np.int32], support_points: npt.NDArray[np.int32]
+) -> npt.NDArray[np.float64]:
+    """
+    Create the degrees of freedom for support conditions.
+
+    Parameters
+    ----------
+    nodal_coords : npt.NDArray[np.int32]
+        Coordinates for all nodes.
+    support_points : int | float
+        Preselected support points.
+
+    Returns
+    -------
+    npt.NDArray[np.float64]
+        Flattened array of degrees of freedom.
+    """
+    dof = np.ones((len(nodal_coords), 2))
+    for i, node in enumerate(nodal_coords):
+        if support_points.size == 0:
+            if node[0] == 0:
+                dof[i, :] = [0, 0]  # Support nodes with x=0
+        else:
+            dof[i, :] = (
+                [0, 0]
+                if any((node == point).all() for point in support_points)
+                else [1, 1]
+            )
+    return np.array(dof).flatten()
+
+
 # Main function - edited for pattern loading
 def trussopt(
     parameters: Parameters,
@@ -642,7 +674,6 @@ def trussopt(
     logger.debug(f"Points created : {len(points)=}")
     nodal_coords = np.array([[pt.x, pt.y] for pt in points if poly.intersects(pt)])
     logger.debug(f"Node coordinates :\n{nodal_coords=}")
-    dof: npt.NDArray[Any] = np.ones((len(nodal_coords), 2))
     # ns-rse 2026-05-13 Build a list of nodes to be added to Structure where do loading and virtual_displacements come from?
     # all_nodes = [
     #     Node(coordinate=param[0], supported_dof=param[1])
@@ -650,26 +681,18 @@ def trussopt(
     # ]
 
     # Default load point
-    parameters.loaded_points = (
-        np.asarray([[parameters.width, parameters.height // 2]])
-        if parameters.loaded_points is None
-        else parameters.loaded_points
+    if parameters.loaded_points is None:
+        parameters.loaded_points = np.asarray(
+            [[parameters.width, parameters.height // 2]]
+        )
+        logger.info(
+            f"Loaded points not provided, calculated as : {parameters.loaded_points=}"
+        )
+    # Calculate support conditions/degrees of freedom
+    dof = _support_conditions(
+        nodal_coords=nodal_coords, support_points=parameters.support_points
     )
-    logger.debug(f"Loaded points are : {parameters.loaded_points=}")
-    # support conditions
-    for i, node in enumerate(nodal_coords):
-        if parameters.support_points.size == 0:
-            if node[0] == 0:
-                dof[i, :] = [0, 0]  # Support nodes with x=0
-        else:
-            dof[i, :] = (
-                [0, 0]
-                if any((node == point).all() for point in parameters.support_points)
-                else [1, 1]
-            )
     logger.debug(f"Degrees of Freedom : {dof=}")
-    dof = np.array(dof).flatten()
-
     # Generate all pattern loads
     # ns-rse 2026-03-17 : Unused return arguments but may combine all_patterns and pattern_descriptions to dict
     # all_patterns, base_load, pattern_descriptions = make_pattern_loads(

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -676,6 +676,32 @@ def _potential_members(
                 potential_members.append([i, j, length, False])
     return np.asarray(potential_members)
 
+
+def _primal_adaptivity(
+    primal_method: str, all_patterns_length: int
+) -> tuple[bool, npt.NDArray[np.int32]]:
+    """
+    Derive primal method and active load cases. Start with base load for cases only.
+
+    Parameters
+    ----------
+    primal_method : str
+        Primal method.
+    all_patterns_length : int
+        All patterns.
+
+    Returns
+    -------
+    tuple[bool, npt.NDArray[np.int32]]
+        A tuple of a boolean for ``primal_method`` and the associated ``active_load_cases``.
+    """
+    if primal_method in {"residual", "load_factor"}:
+        active_load_cases = np.zeros(all_patterns_length, dtype=int)
+        active_load_cases[0] = 1  # Base case = all large loads
+        return (True, active_load_cases)
+    return (False, np.ones(all_patterns_length, dtype=int))
+
+
 # Main function - edited for pattern loading
 def trussopt(
     parameters: Parameters,
@@ -767,20 +793,9 @@ def trussopt(
         pm[3] = True
 
     #### Primal adaptivity: start with base load case only ####
-    primal_adaptivity = True
-    # if PrimalAdaptivity:
-    #     activeLoadCases = np.zeros(len(allPatterns), dtype=int)
-    #     activeLoadCases[0] = 1  # Base case = all large loads
-    # # does below make sense here?
-    # else:
-    #     activeLoadCases = np.ones(len(allPatterns), dtype=int)
-    if parameters.primal_method in {"residual", "load_factor"}:
-        primal_adaptivity = True
-        active_load_cases = np.zeros(len(all_patterns), dtype=int)
-        active_load_cases[0] = 1  # Base case = all large loads
-    else:
-        primal_adaptivity = False
-        active_load_cases = np.ones(len(all_patterns), dtype=int)
+    primal_adaptivity, active_load_cases = _primal_adaptivity(
+        primal_method=parameters.primal_method, all_patterns_length=len(all_patterns)
+    )
 
     setup_end = time.process_time()
     logger.info(f"Setup took {setup_end - setup_start!s}")

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -634,6 +634,48 @@ def _support_conditions(
     return np.array(dof).flatten()
 
 
+def _potential_members(
+    node_coords: npt.NDArray,
+    max_length: float,
+    joint_cost: float,
+    convex: bool,
+    polygon: Polygon,
+) -> npt.NDArray[np.float64]:
+    """
+    Create the ground structure.
+
+    Parameters
+    ----------
+    node_coords : npt.NDArray,
+        Node coordinates.
+    max_length : int | float,
+        Maximum length.
+    joint_cost : int | float,
+        Joint cost.
+    convex : bool,
+        Whether the structure is convex.
+    polygon : Polygon
+        Bounding box for the structure.
+
+    Returns
+    -------
+    npt.NDArray[np.float64]
+        Array of ground structure coordinates.
+    """
+    potential_members = []
+    for i, j in itertools.combinations(range(len(node_coords)), 2):
+        dx, dy = (
+            abs(node_coords[i][0] - node_coords[j][0]),
+            abs(node_coords[i][1] - node_coords[j][1]),
+        )
+        length = np.sqrt(dx**2 + dy**2)
+        # Remove overlapping members, or members longer than maxLength
+        if (length < max_length and gcd(int(dx), int(dy)) == 1) or joint_cost != 0:
+            seg = [] if convex else LineString([node_coords[i], node_coords[j]])
+            if convex or polygon.contains(seg) or polygon.boundary.contains(seg):
+                potential_members.append([i, j, length, False])
+    return np.asarray(potential_members)
+
 # Main function - edited for pattern loading
 def trussopt(
     parameters: Parameters,
@@ -706,21 +748,13 @@ def trussopt(
     )
 
     # Create the 'ground structure'
-    _potential_members = []
-    for i, j in itertools.combinations(range(len(nodal_coords)), 2):
-        dx, dy = (
-            abs(nodal_coords[i][0] - nodal_coords[j][0]),
-            abs(nodal_coords[i][1] - nodal_coords[j][1]),
-        )
-        length = np.sqrt(dx**2 + dy**2)
-        # Remove overlapping members, or members longer than maxLength
-        if (
-            length < parameters.max_length and gcd(int(dx), int(dy)) == 1
-        ) or parameters.joint_cost != 0:
-            seg = [] if convex else LineString([nodal_coords[i], nodal_coords[j]])
-            if convex or poly.contains(seg) or poly.boundary.contains(seg):
-                _potential_members.append([i, j, length, False])
-    potential_members = np.array(_potential_members)
+    potential_members = _potential_members(
+        node_coords=nodal_coords,
+        max_length=parameters.max_length,
+        joint_cost=parameters.joint_cost,
+        convex=convex,
+        polygon=poly,
+    )
 
     # Create the active members
     # DualAdaptivity = True

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -602,16 +602,16 @@ def stop_primal_violation_pattern(
 
 
 def _support_conditions(
-    nodal_coords: npt.NDArray[np.int32], support_points: npt.NDArray[np.int32]
+    nodal_coords: npt.NDArray[np.float64], support_points: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:
     """
     Create the degrees of freedom for support conditions.
 
     Parameters
     ----------
-    nodal_coords : npt.NDArray[np.int32]
+    nodal_coords : npt.NDArray[np.float64]
         Coordinates for all nodes.
-    support_points : int | float
+    support_points : npt.NDArray[np.float64]
         Preselected support points.
 
     Returns
@@ -634,7 +634,7 @@ def _support_conditions(
 
 
 def _potential_members(
-    node_coords: npt.NDArray,
+    nodal_coords: npt.NDArray,
     max_length: float,
     joint_cost: float,
     convex: bool,
@@ -645,7 +645,7 @@ def _potential_members(
 
     Parameters
     ----------
-    node_coords : npt.NDArray,
+    nodal_coords : npt.NDArray,
         Node coordinates.
     max_length : int | float,
         Maximum length.
@@ -662,15 +662,15 @@ def _potential_members(
         Array of ground structure coordinates.
     """
     potential_members = []
-    for i, j in itertools.combinations(range(len(node_coords)), 2):
+    for i, j in itertools.combinations(range(len(nodal_coords)), 2):
         dx, dy = (
-            abs(node_coords[i][0] - node_coords[j][0]),
-            abs(node_coords[i][1] - node_coords[j][1]),
+            abs(nodal_coords[i][0] - nodal_coords[j][0]),
+            abs(nodal_coords[i][1] - nodal_coords[j][1]),
         )
         length = np.sqrt(dx**2 + dy**2)
         # Remove overlapping members, or members longer than maxLength
         if (length < max_length and gcd(int(dx), int(dy)) == 1) or joint_cost != 0:
-            seg = [] if convex else LineString([node_coords[i], node_coords[j]])
+            seg = [] if convex else LineString([nodal_coords[i], nodal_coords[j]])
             if convex or polygon.contains(seg) or polygon.boundary.contains(seg):
                 potential_members.append([i, j, length, False])
     return np.asarray(potential_members)
@@ -739,7 +739,9 @@ def trussopt(
     # xv, yv = np.meshgrid(range(parameters.width + 1), range(parameters.height + 1))
     points = [Point(xv.flat[i], yv.flat[i]) for i in range(xv.size)]
     logger.debug(f"Points created : {len(points)=}")
-    nodal_coords = np.array([[pt.x, pt.y] for pt in points if poly.intersects(pt)])
+    nodal_coords: npt.NDArray[np.float64] = np.array(
+        [[pt.x, pt.y] for pt in points if poly.intersects(pt)]
+    )
     logger.debug(f"Node coordinates :\n{nodal_coords=}")
     # ns-rse 2026-05-13 Build a list of nodes to be added to Structure where do loading and virtual_displacements come from?
     # all_nodes = [
@@ -774,7 +776,7 @@ def trussopt(
 
     # Create the 'ground structure'
     potential_members = _potential_members(
-        node_coords=nodal_coords,
+        nodal_coords=nodal_coords,
         max_length=parameters.max_length,
         joint_cost=parameters.joint_cost,
         convex=convex,

--- a/src/layopt/validation.py
+++ b/src/layopt/validation.py
@@ -121,7 +121,7 @@ LAYOPT_CONFIG_SCHEMA = Schema(
         "member_area_filtering": Or(
             And(int, lambda n: 1 >= n >= 0),
             And(float, lambda n: 1.0 >= n >= 0.0),
-            error="❌ Invalid value in config for 'member_area_filtering', valid values are >= 0.0 and <= 1.0.",
+            error="Invalid value in config for 'member_area_filtering', valid values are >= 0.0 and <= 1.0.",
         ),
         "filter_levels": And(
             np.ndarray,

--- a/src/layopt/validation.py
+++ b/src/layopt/validation.py
@@ -68,6 +68,11 @@ LAYOPT_CONFIG_SCHEMA = Schema(
             lambda n: n >= 1,
             error="Invalid value in config for 'height', valid values are int >= 1.",
         ),
+        "steps": Or(
+            And(int, lambda n: n >= 1),
+            And(float, lambda n: n > 0.0),
+            error="Invalid value in config for 'steps', valid values are > 0.0.",
+        ),
         "stress_tensile": Or(
             And(int, lambda n: n >= 0),
             And(float, lambda n: n >= 0.0),

--- a/tests/test_layopt.py
+++ b/tests/test_layopt.py
@@ -802,3 +802,65 @@ def test_stop_violation(
     assert isinstance(actual_num_added, int)
     assert actual_num_added >= 0
     assert actual_num_added == expected_num_added
+
+
+@pytest.mark.parametrize(
+    ("node_coords", "support_points", "expected"),
+    [
+        pytest.param(
+            np.asarray(
+                [
+                    [0, 0],
+                    [0, 1],
+                    [1, 0],
+                    [1, 1],
+                ]
+            ),
+            np.asarray([]),
+            np.asarray([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]),
+            id="simple 1x1 square, no support points defined",
+        ),
+        pytest.param(
+            np.asarray(
+                [
+                    [0, 0],
+                    [0, 1],
+                    [0, 2],
+                    [1, 0],
+                    [1, 1],
+                    [1, 2],
+                ]
+            ),
+            np.asarray([]),
+            np.asarray([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            id="simple 2x3 rectangle, no support points defined",
+        ),
+        pytest.param(
+            np.asarray(
+                [
+                    [0, 0],
+                    [0, 1],
+                    [0, 2],
+                    [1, 0],
+                    [1, 1],
+                    [1, 2],
+                ]
+            ),
+            np.asarray([[0, 0], [0, 2]]),
+            np.asarray([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            id="simple 2x3 rectangle, two support points defined",
+        ),
+    ],
+)
+def test_support_conditions(
+    node_coords: npt.NDArray[np.int64],
+    support_points: npt.NDArray[np.int64],
+    expected: npt.NDArray[np.int64],
+) -> None:
+    """Test for ``layopt.support_conditions()``."""
+    np.testing.assert_array_equal(
+        layopt.support_conditions(
+            nodal_coords=node_coords, support_points=support_points
+        ),
+        expected,
+    )

--- a/tests/test_layopt.py
+++ b/tests/test_layopt.py
@@ -806,7 +806,7 @@ def test_stop_violation(
 
 
 @pytest.mark.parametrize(
-    ("node_coords", "support_points", "expected"),
+    ("nodal_coords", "support_points", "expected"),
     [
         pytest.param(
             np.asarray(
@@ -854,21 +854,21 @@ def test_stop_violation(
     ],
 )
 def test_support_conditions(
-    node_coords: npt.NDArray[np.int64],
+    nodal_coords: npt.NDArray[np.int64],
     support_points: npt.NDArray[np.int64],
     expected: npt.NDArray[np.int64],
 ) -> None:
     """Test for ``layopt._support_conditions()``."""
     np.testing.assert_array_equal(
         layopt._support_conditions(
-            nodal_coords=node_coords, support_points=support_points
+            nodal_coords=nodal_coords, support_points=support_points
         ),
         expected,
     )
 
 
 @pytest.mark.parametrize(
-    ("node_coords", "max_length", "joint_cost", "convex", "polygon", "expected"),
+    ("nodal_coords", "max_length", "joint_cost", "convex", "polygon", "expected"),
     [
         pytest.param(
             np.asarray([[0, 0], [0, 1], [1, 0], [1, 1]]),
@@ -885,11 +885,26 @@ def test_support_conditions(
                 ]
             ),
             id="Basic square",
-        )
+        ),
+        pytest.param(
+            np.asarray([[0, 0], [0, 1], [1, 0]]),
+            1,
+            0.6,
+            False,
+            Polygon(np.asarray([[0, 0], [0, 1], [1, 0]])),
+            np.asarray(
+                [
+                    [0.0, 1.0, 1.0, 0.0],
+                    [0.0, 2.0, 1.0, 0.0],
+                    [1.0, 2.0, 1.4142135623730951, 0.0],
+                ]
+            ),
+            id="Basic triangle",
+        ),
     ],
 )
 def test_potential_members(
-    node_coords: npt.NDArray[np.int64],
+    nodal_coords: npt.NDArray[np.int64],
     max_length: float,
     joint_cost: float,
     convex: bool,
@@ -899,7 +914,7 @@ def test_potential_members(
     """Test for ``layopt._potential_members()``."""
     np.testing.assert_array_equal(
         layopt._potential_members(
-            node_coords=node_coords,
+            nodal_coords=nodal_coords,
             max_length=max_length,
             joint_cost=joint_cost,
             convex=convex,

--- a/tests/test_layopt.py
+++ b/tests/test_layopt.py
@@ -866,6 +866,7 @@ def test_support_conditions(
         expected,
     )
 
+
 @pytest.mark.skip(reason="Awaiting parameterisation.")
 @pytest.mark.parametrize(
     ("node_coords", "max_length", "joint_cost", "convex", "polygon", "expected"),
@@ -884,7 +885,41 @@ def test_potential_members(
     """Test for ``layopt._potential_members()``."""
     np.testing.assert_array_equal(
         layopt._potential_members(
-            node_coords=node_coords, max_length=max_length,joint_cost=joint_cost, convex=convex, polygon=polygon
+            node_coords=node_coords,
+            max_length=max_length,
+            joint_cost=joint_cost,
+            convex=convex,
+            polygon=polygon,
         ),
         expected,
+    )
+
+
+@pytest.mark.skip(reason="Awaiting parameterisation.")
+@pytest.mark.parametrize(
+    ("primal_method", "all_patterns_length", "expected_primal_method", "expected_active_load_cases"),
+    [
+        pytest.param(
+            "residual", 4, True, np.asarray([1, 0, 0, 0]), id="residual of length 4"
+        ),
+        pytest.param(
+            "load_factor", 4, True, np.asarray([1, 0, 0, 0]), id="load_factor of length 4"
+        ),
+        pytest.param("other", 4, False, np.asarray([1, 1, 1, 1]), id="other of length 4"),
+    ],
+)
+def test_primal_adaptivity(
+    primal_method: str,
+    all_patterns_length: int,
+    expected_primal_method: bool,
+    expected_active_load_cases: npt.NDArray[np.int32],
+) -> None:
+    """Test for ``layopt._primal_adaptivity()``."""
+    primal_method_result, active_load_cases = layopt._primal_adaptivity(
+            primal_method=primal_method, all_patterns_length=all_patterns_length
+        )
+    assert primal_method_result == expected_primal_method
+    np.testing.assert_array_equal(
+        active_load_cases,
+        expected_active_load_cases,
     )

--- a/tests/test_layopt.py
+++ b/tests/test_layopt.py
@@ -7,6 +7,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 from syrupy.matchers import path_type
+from shapely.geometry import Polygon
 
 from layopt import layopt
 
@@ -857,10 +858,33 @@ def test_support_conditions(
     support_points: npt.NDArray[np.int64],
     expected: npt.NDArray[np.int64],
 ) -> None:
-    """Test for ``layopt.support_conditions()``."""
+    """Test for ``layopt._support_conditions()``."""
     np.testing.assert_array_equal(
-        layopt.support_conditions(
+        layopt._support_conditions(
             nodal_coords=node_coords, support_points=support_points
+        ),
+        expected,
+    )
+
+@pytest.mark.skip(reason="Awaiting parameterisation.")
+@pytest.mark.parametrize(
+    ("node_coords", "max_length", "joint_cost", "convex", "polygon", "expected"),
+    [
+        pytest.param(),
+    ],
+)
+def test_potential_members(
+    node_coords: npt.NDArray[np.int64],
+    max_length: int | float,
+    joint_cost: float,
+    convex: bool,
+    polygon: Polygon,
+    expected: npt.NDArray,
+) -> None:
+    """Test for ``layopt._potential_members()``."""
+    np.testing.assert_array_equal(
+        layopt._potential_members(
+            node_coords=node_coords, max_length=max_length,joint_cost=joint_cost, convex=convex, polygon=polygon
         ),
         expected,
     )

--- a/tests/test_layopt.py
+++ b/tests/test_layopt.py
@@ -6,8 +6,8 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import pytest
-from syrupy.matchers import path_type
 from shapely.geometry import Polygon
+from syrupy.matchers import path_type
 
 from layopt import layopt
 
@@ -867,16 +867,30 @@ def test_support_conditions(
     )
 
 
-@pytest.mark.skip(reason="Awaiting parameterisation.")
 @pytest.mark.parametrize(
     ("node_coords", "max_length", "joint_cost", "convex", "polygon", "expected"),
     [
-        pytest.param(),
+        pytest.param(
+            np.asarray([[0, 0], [0, 1], [1, 0], [1, 1]]),
+            1,
+            0.6,
+            False,
+            Polygon(np.asarray([[0, 0], [0, 1], [1, 0], [1, 1]])),
+            np.asarray(
+                [
+                    [0.0, 1.0, 1.0, 0.0],
+                    [0.0, 3.0, 1.4142135623730951, 0.0],
+                    [1.0, 2.0, 1.4142135623730951, 0.0],
+                    [2.0, 3.0, 1.0, 0.0],
+                ]
+            ),
+            id="Basic square",
+        )
     ],
 )
 def test_potential_members(
     node_coords: npt.NDArray[np.int64],
-    max_length: int | float,
+    max_length: float,
     joint_cost: float,
     convex: bool,
     polygon: Polygon,
@@ -895,17 +909,27 @@ def test_potential_members(
     )
 
 
-@pytest.mark.skip(reason="Awaiting parameterisation.")
 @pytest.mark.parametrize(
-    ("primal_method", "all_patterns_length", "expected_primal_method", "expected_active_load_cases"),
+    (
+        "primal_method",
+        "all_patterns_length",
+        "expected_primal_method",
+        "expected_active_load_cases",
+    ),
     [
         pytest.param(
             "residual", 4, True, np.asarray([1, 0, 0, 0]), id="residual of length 4"
         ),
         pytest.param(
-            "load_factor", 4, True, np.asarray([1, 0, 0, 0]), id="load_factor of length 4"
+            "load_factor",
+            4,
+            True,
+            np.asarray([1, 0, 0, 0]),
+            id="load_factor of length 4",
         ),
-        pytest.param("other", 4, False, np.asarray([1, 1, 1, 1]), id="other of length 4"),
+        pytest.param(
+            "other", 4, False, np.asarray([1, 1, 1, 1]), id="other of length 4"
+        ),
     ],
 )
 def test_primal_adaptivity(
@@ -916,8 +940,8 @@ def test_primal_adaptivity(
 ) -> None:
     """Test for ``layopt._primal_adaptivity()``."""
     primal_method_result, active_load_cases = layopt._primal_adaptivity(
-            primal_method=primal_method, all_patterns_length=all_patterns_length
-        )
+        primal_method=primal_method, all_patterns_length=all_patterns_length
+    )
     assert primal_method_result == expected_primal_method
     np.testing.assert_array_equal(
         active_load_cases,


### PR DESCRIPTION
This pulls out some of the steps from `laypopt.trussopt()` that creates the necessary structures into small testable,
stand-alone functions and adds simple unit tests for them.

The reason for doing this is...

- break code down into small testable functions and avoid having `trussopt()` doing lots of things
- make the steps modular so that we can write a `Structure` dataclass with a `__post_init__()` method that will create
  the structure on instantiation.

---

Before submitting a Pull Request please check the following.

- [X] Existing tests pass.
- [ ] ~Documentation has been updated and builds.~
- [X] Pre-commit checks pass.
- [X] New functions/methods have typehints and docstrings.
- [X] New functions/methods have tests which check the intended behaviour is correct.