### PR TITLE
ci|docs: Add pypi.yaml workflow and update install docs

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,81 @@
+name: Publish package to PyPi
+# See https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch: # Uncomment line if you also want to trigger action manually
+
+jobs:
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v6
+      - name: Install uv and set the Python version
+        uses: astral-sh/setup-uv@v7
+        with:
+          activate-environment: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install the package
+        run: |
+          uv sync --locked --all-extras --dev
+      - name: Build package
+        run: |
+          uv pip install --upgrade setuptools
+          export DEB_PYTHON_INSTALL_LAYOUT=deb_system
+          python -m build --no-isolation
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/layopt
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+    environment:
+      name: pypi
+      url: https://test.pypi.org/p/layopt
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,8 +1,36 @@
 # Installation
 
+There are a number of different options for installing LayOpt depending on whether you want to just use a stable
+release, a development version or contribute to development.
+
+Once installed please refer to the [usage instructions](usage.md).
+
+## Virtual Environment
+
+It is recommended that you use a [Python Virtual Environment][pyvenv] to install LayOpt. There are many options
+available but a good choice, used in the development of LayOpt, is [uv][uv]. Create a directory for your work and after
+[installing uv][uv_install] create a virtual environment.
+
+```shell
+# Create a directory
+mkdir LayOpt
+# Change directory
+cd LayOpt
+# Create a virtual Environment
+uv venv
+```
+
 ## PyPI
 
-**LayOpt** is not yet published to PyPI, for now you will have to install from GitHub.
+Released versions are available for installation from [PyPI][pypi]. Ideally you should use a Python Virtual Environment
+(see above).
+
+```shell
+# Plain virtual environment
+pip install layopt
+# uv virtual environment
+uv pip install layopt
+```
 
 ## GitHub
 
@@ -40,6 +68,24 @@ uv pip install --group dev
 pre-commit install
 ```
 
+### Style and Linting
+
+We use a number of [pre-commit][precommit] hooks to ensure the codebase follows the [PEP8][pep8] style guide and
+functions/methods, classes and modules are documented using [numpydoc Style][numpydoc]. After installing the pre-commit
+hooks you will find when making a commit that the hooks are run against the changes being submitted. Sometimes the hooks
+will reformat the files to ensure they follow the guidelines, but not all changes can, or should, be applied
+automatically and you will have to review the output and make the changes, stage and commit (`--amend`) to ensure the
+hooks pass.
+
+Of particular note is ensuring the typehints are consistent as we use [mypy][mypy] to run static type checking against
+the code base. For details of all hooks used see the `.pre-commit-config.yaml` file in the repository.
+
+[mypy]: https://mypy.readthedocs.io/en/stable/getting_started.html
+[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
+[pep8]: https://pep8.org/
 [pip]: https://pip.pypa.io/en/stable/installation/
+[precommit]: https://precommit.com/
+[pypi]: https://pypi.org/
+[pyvenv]: https://realpython.com/python-virtual-environments-a-primer/
 [uv]: https://docs.astral.sh/uv/
 [uv_install]: https://docs.astral.sh/uv/getting-started/installation/


### PR DESCRIPTION
Closes #114

- adds `.github/workflows/pypi.yaml` which publishes tagged commits that begin with `v` to PyPI. The job can be run
manually for testing which should publish to TestPyPI
- Improves the `installation.md` file with details on installing from different sources.

---

- [ ] ~Existing tests pass.~
- [X] Documentation has been updated and builds.
- [X] Pre-commit checks pass.
- [ ] ~New functions/methods have typehints and docstrings.~
- [ ] ~New functions/methods have tests which check the intended behaviour is correct.~

<!-- Message of single commit: -->