### PR TITLE
ci: Remove tests|noxfile.py from mypy files: pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
     rev: "v2.1.0"
     hooks:
       - id: mypy
-        files: src|tests|noxfile.py
+        files: src
         args: []
         additional_dependencies:
           - nox


### PR DESCRIPTION
Closes #117

The `mypy` pre-commit hook explicitly included `files: src|tests|noxfile.py` which is why pre-commit.ci was including
`tests/` even though in `pyproject.toml` we only configure `src/` directory.🤦

---


- [X] Pre-commit checks pass.

<!-- Message of single commit: -->