### PR TITLE
pyproject.toml: switch to hatchling for dynamic versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ pip install layopt
 uv pip install layopt
 ```
 
+#### Pre-releases
+
+If you wish to try pre-releases, denoted by suffixes of the form `a#` for alpha releases, `b#` for beta and `rc#` for
+release candidates you should include the specific version when calling `pip`. For example to install the `0.1.0a1`
+(first alpha release of version 0.1.0) you would use...
+
+``` shell
+# Plain virtual environment
+pip install layopt==0.1.0a1
+# uv virtual environment
+uv pip install layopt==0.1.0a1
+```
+
 ### GitHub
 
 You can use [`pip`][pip] to install the package directly from GitHub. This allows you to install a specific branch or

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,6 +32,19 @@ pip install layopt
 uv pip install layopt
 ```
 
+### Pre-releases
+
+If you wish to try pre-releases, denoted by suffixes of the form `a#` for alpha releases, `b#` for beta and `rc#` for
+release candidates you should include the specific version when calling `pip`. For example to install the `0.1.0a1`
+(first alpha release of version 0.1.0) you would use...
+
+``` shell
+# Plain virtual environment
+pip install layopt==0.1.0a1
+# uv virtual environment
+uv pip install layopt==0.1.0a1
+```
+
 ## GitHub
 
 You can use [`pip`][pip] to install the package directly from GitHub. This allows you to install a specific branch or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["uv_build>=0.7.19"]
-build-backend = "uv_build"
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
 
 
 [project]
 name = "LayOpt"
-version = "0.1.0"
+dynamic = ["version"]
 authors = [
   { name = "Helen Fairclough", email = "helen.fairclough@sheffield.ac.uk" },
   { name = "Andrew Fisher", email = "andrew.fisher@sheffield.ac.uk" },
@@ -17,7 +17,7 @@ license = "GPL-3.0-or-later"
 license-files = ["COPYING.md"]
 requires-python = ">=3.12"
 classifiers = [
-  "Development Status :: 1 - Planning",
+  "Development Status :: 3 - Alpha",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
@@ -232,6 +232,9 @@ skip = 'uv.lock'
 count = ''
 quiet-level = 3
 # ignore-words-list = ''
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
 
 [project.scripts]
 layopt = "layopt.entry_point:entry_point"

--- a/src/layopt/__init__.py
+++ b/src/layopt/__init__.py
@@ -16,7 +16,7 @@ __release__ = ".".join(__version__.split(".")[:-2])
 LAYOPT_VERSION = Version(__version__)
 if LAYOPT_VERSION.is_prerelease and LAYOPT_VERSION.is_devrelease:
     LAYOPT_BASE_VERSION = str(LAYOPT_VERSION.base_version)
-    LAYOPT_COMMIT = str(LAYOPT_VERSION).split("+g")[1]
+    LAYOPT_COMMIT = str(LAYOPT_VERSION).split("+")[1]
 else:
     LAYOPT_BASE_VERSION = str(LAYOPT_VERSION)
     LAYOPT_COMMIT = ""

--- a/uv.lock
+++ b/uv.lock
@@ -881,7 +881,6 @@ wheels = [
 
 [[package]]
 name = "layopt"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "art" },


### PR DESCRIPTION
Switching to [dynamic versioning using
hatchling](https://pydevtools.com/handbook/how-to/how-to-add-dynamic-versioning-to-uv-projects/) so that we can make a
release on GitHub and apply a tag, this will be built using `uv build`

I've tested this locally by

```
❱ git tag "v0.1.0-alpha"
❱ uv build
Building source distribution...
Building wheel from source distribution...
Successfully built dist/layopt-0.1.0a0.tar.gz
Successfully built dist/layopt-0.1.0a0-py3-none-any.whl
❱ git tag --delete "v0.1.0-alpha"
```

...and was concerned that `-alpha` was switched to `a0` but checking the [Python packaging
guide](https://packaging.python.org/en/latest/discussions/versioning/) this is to be expected and we should use suffixes
of the form...

- `a#` for numbered alpha releases
- `b#` for numbered beta releases
- `rc#` for numbered release candidates

I've added a note to the installation instructions and `README.md` about how to install pre-release candidates as by
default `pip` ignores pre-releases.

---

Before submitting a Pull Request please check the following.

- [X] Documentation has been updated and builds.
- [X] Pre-commit checks pass.

<!-- Message of single commit: -->