### PR TITLE
fix: Add mosek to dev dependencies; docs: testing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ description of why a particular item is not relevant.
 
 Before submitting a Pull Request please check the following.
 
+- [ ] I have a MOSEK license.
 - [ ] Existing tests pass.
 - [ ] Documentation has been updated and builds.
 - [ ] Pre-commit checks pass.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,6 +118,12 @@ repos:
       - id: numpydoc-validation
         exclude: ^noxfile.py$
 
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.11.26
+    hooks:
+      - id: uv-lock
+
   - repo: local
     hooks:
       - id: pylint

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,17 +89,25 @@ compared.
 The tests are run as part of our Continuous Integration when Pull Requests are made on several different versions of
 Python across several different operating systems.
 
-When making contributions we would ask that as a bare minimum you ensure all existing tests pass. Sometimes if fixing a
-bug then the [syrupy][syrupy] snapshots may need updating too.
+When making contributions we would ask that as a bare minimum you try and ensure all existing tests pass. Sometimes if
+fixing a bug then the [syrupy][syrupy] snapshots may need updating too.
 
 ### Mosek
 
-One of the development dependencies is the [Mosek][mosek] solver library and our test suite uses this solver when
+One of the development dependencies is the [MOSEK][mosek] solver library and our test suite uses this solver when
 running tests locally. Whilst this can be installed from PyPI running/using it requires a license to be placed in the
 `~/mosek`. These licenses are [free for academics][mosek_license] but commercial use incurs a [license
-fee][mosek_fee]. It is worth noting though that the use of [Mosek][mosek] is not essential as we utilise [cvxpy][cvxpy]
+fee][mosek_fee]. It is worth noting though that the use of [MOSEK][mosek] is not essential as we utilise [cvxpy][cvxpy]
 library for convex optimisation which provides a flexible approach to selecting solvers and we use the
 [clarabel][clarabel] package as a default dependency.
+
+<!-- markdownlint-disable MD046 -->
+!!! failure
+
+    If you do not have a [Mosek](#mosek) license then these tests will always fail and as they are not run in Continuous
+    Integration. We ask that you highlight the lack of a license in the pull request check list and a project member
+    will run the tests locally when reviewing the pull request.
+<!-- markdownlint-enable MD046 -->
 
 [clarabel]: https://clarabel.org/stable/python/getting_started_py/
 [cvxpy]: https://www.cvxpy.org/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,7 +34,7 @@ uv env
 # Synchronise and install the package and its dependencies
 uv sync
 # Install the development packages
-uv pip install --group dev
+uv pip install -e . --group dev
 ```
 
 ## Linting and Style
@@ -71,17 +71,54 @@ the Git command line by using the `-n` flag). The hooks also run in the Continuo
 pull requests are created and errors there will be highlighted and need fixing prior to approving and merging pull
 requests.
 
+## Tests
+
+We have a comprehensive test-suite that that can be found in the `tests/` directory and uses the [pytest][pytest]
+framework. Assuming you have installed `layopt` with all of the development dependencies as described above these tests
+can be run locally.
+
+```shell
+pytest
+# To run in parallel with 6 processes
+pytest -n 6
+```
+
+In a number of places we use the [syrupy][syrupy] extension which makes snapshots of results against which the tests are
+compared.
+
+The tests are run as part of our Continuous Integration when Pull Requests are made on several different versions of
+Python across several different operating systems.
+
+When making contributions we would ask that as a bare minimum you ensure all existing tests pass. Sometimes if fixing a
+bug then the [syrupy][syrupy] snapshots may need updating too.
+
+### Mosek
+
+One of the development dependencies is the [Mosek][mosek] solver library and our test suite uses this solver when
+running tests locally. Whilst this can be installed from PyPI running/using it requires a license to be placed in the
+`~/mosek`. These licenses are [free for academics][mosek_license] but commercial use incurs a [license
+fee][mosek_fee]. It is worth noting though that the use of [Mosek][mosek] is not essential as we utilise [cvxpy][cvxpy]
+library for convex optimisation which provides a flexible approach to selecting solvers and we use the
+[clarabel][clarabel] package as a default dependency.
+
+[clarabel]: https://clarabel.org/stable/python/getting_started_py/
+[cvxpy]: https://www.cvxpy.org/
 [black]: https://black.readthedocs.io/en/stable/
 [codespell]: https://github.com/codespell-project/codespell
 [conventional_commit]: https://www.conventionalcommits.org/en/v1.0.0/
+[mosek]: https://www.mosek.com/
+[mosek_fee]: https://www.mosek.com/sales/commercial-pricing/
+[mosek_license]: https://www.mosek.com/products/academic-licenses/
+[mypy]: https://www.mypy-lang.org/
 [numpydoc]: https://numpydoc.readthedocs.io/en/latest/
 [numpydoc_validation]: https://numpydoc.readthedocs.io/en/latest/validation.html
-[mypy]: https://www.mypy-lang.org/
 [pep8]: https://peps.python.org/pep-0008/
 [pre-commit]: https://pre-commit.com/
 [prettier]: https://prettier.io/
 [pylint]: https://pylint.readthedocs.io/en/stable/
+[pytest]: https://docs.pytest.org/en/stable/
 [ruff]: https://docs.astral.sh/ruff/
+[syrupy]: https://syrupy-project.github.io/syrupy/
 [uv]: https://docs.astral.sh/uv/
 [uv_install]: https://docs.astral.sh/uv/getting-started/installation/
 [venv]: https://docs.python.org/3/library/venv.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,8 @@ plugins:
   search: {}
 
 markdown_extensions:
+  - admonition
+  - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
   "black",
   "codespell",
   "ipdb",
+  "mosek",
   "mypy",
   "pre-commit",
   "pydocstyle[toml]",

--- a/uv.lock
+++ b/uv.lock
@@ -912,6 +912,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings-python" },
+    { name = "mosek" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pydocstyle" },
@@ -977,6 +978,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings-python", specifier = ">=2.0.3" },
+    { name = "mosek" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pydocstyle", extras = ["toml"] },
@@ -1386,6 +1388,20 @@ wheels = [
 ]
 
 [[package]]
+name = "mosek"
+version = "11.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/fa/cafd7af72c090e4c13d35124264803ad4bf5cf80d24de470846f3bfc8d9b/mosek-11.2.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:15a6fd2be996e4dd01d5130f876937db4137dcb660e5128944c9363fd51cf119", size = 8794686, upload-time = "2026-06-10T05:59:50.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/06/25814cec5fbc4dc93190c0f37afcdd24b83efe570d598ca3c21c610cb543/mosek-11.2.2-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:77c9f2c86e9adc0a8da9a44c9cf2e0e7dc4eecae850e5295855abb628b7755be", size = 15364494, upload-time = "2026-06-10T05:59:55.452Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7c/fd1f85cd13a4bcf84aa620c74aa28ad7872d319d6645a53018f8560bf52e/mosek-11.2.2-cp39-abi3-manylinux_2_27_aarch64.whl", hash = "sha256:f3debca608fcaac8b7129975e0ad5083d89844ba4658f48ed18fec420e0ddaf0", size = 9909410, upload-time = "2026-06-10T05:59:58.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/19/cceda5079e8416b8353dd0d1ef71c70004d5bbd43fcdf34f797a87c315f0/mosek-11.2.2-cp39-abi3-win_amd64.whl", hash = "sha256:0ffe2125658f83110771caf0d8b83b40f1c4b0d1b18c2083b37757b719aa070c", size = 11201973, upload-time = "2026-06-10T06:00:01.89Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1672,7 +1688,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
Closes #132

- Adds mosek as a dev dependency in `pyproject.toml`
- Adds a section to `docs/contributing.md` on testing and highlights the need for a Mosek license to run the tests
  locally.
- Adds [`uv-lock`](https://docs.astral.sh/uv/guides/integration/pre-commit/) pre-commit hook as yet again I failed to remember to run `uv lock` after modifying the dependencies in `pyproject.toml`

---

Before submitting a Pull Request please check the following.

- [ ] ~Existing tests pass.~
- [X] Documentation has been updated and builds.
- [X] Pre-commit checks pass.
- [ ] ~New functions/methods have typehints and docstrings.~
- [ ] ~New functions/methods have tests which check the intended behaviour is correct.~

<!-- Message of single commit: -->