### PR TITLE
refactor(io): Use Parameter class as basis for writing configs

### DIFF
--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -46,7 +46,7 @@ class Parameters:
         default=0.001, title="Member Area Filtering", ge=0.0
     )
     cvxpy: dict[str, Any] = Field(
-        default={"solver": "mosek"},
+        default={"solver": "clarabel"},
         title="CVXPY options.",
     )
     primal_method: str = Field(default="load_factor", title="Primal method")

--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -48,7 +48,7 @@ class Parameters:
         default=1.5, title="Active member threshold", gt=0.0
     )
     support_points: npt.NDArray[np.float32] = Field(
-        default=np.asarray([[3, 3]]), title="Support Points."
+        default=np.asarray([[0, 0], [3, 3]]), title="Support Points."
     )
     member_area_filtering: float = Field(
         default=0.001, title="Member Area Filtering", ge=0.0

--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -22,8 +22,16 @@ from layopt import structure
 class Parameters:
     """Modelling parameters."""
 
+    base_dir: Path = Field(default=Path("./"), title="Base directory")
+    output_dir: str | Path = Field(
+        default=Path("./output/"),
+        title="Path to save the output to, default is './output/'.",
+    )
+    log_level: str = Field(default="info", title="Log level")
+    cores: int = Field(default=2, title="Cores to run optimisation on in parallel.")
     width: int = Field(default=3, title="Width of structure.", ge=1)
     height: int = Field(default=6, title="Height of structure.", ge=1)
+    steps: float = Field(default=1.0, title="Steps to generate nodes", gt=0.0)
     stress_tensile: float = Field(default=1.0, title="Tensile stress.", ge=0.0)
     stress_compressive: float = Field(default=1.0, title="Compressive stress.", ge=0.0)
     joint_cost: float = Field(default=0.0, title="Joint cost.", ge=0.0)
@@ -49,26 +57,21 @@ class Parameters:
         default={"solver": "clarabel"},
         title="CVXPY options.",
     )
+    filter_levels: list[float] = Field(
+        default=[1.0], title="Filter levels to apply to solved problem."
+    )
     primal_method: str = Field(default="load_factor", title="Primal method")
     problem_name: str = Field(
         default="", title="Description of the problem being solved."
     )
-    log_level: str = Field(default="info", title="Log level")
-    notes: str = Field(default="", title="Notes to add to the model.")
-    output_dir: str | Path = Field(
-        default="./output/", title="Path to save the output to, default is './output/'."
-    )
-    plotting: dict[str, Any] = Field(
-        default={"run": False, "bar_thickness": 0.3, "dpi": 1200},
-        title="Plotting options.",
-    )
-    filter_levels: list[float] = Field(
-        default=[1.0], title="Filter levels to apply to solved problem."
-    )
-    cores: int = Field(default=2, title="Cores to run optimisation on in parallel.")
     csv_filename: str = Field(
         default="results.csv",
         title="File to save results to, default is 'results.csv' (within 'output_dir', i.e. './output/results.csv')",
+    )
+    notes: str = Field(default="", title="Notes to add to the model.")
+    plotting: dict[str, Any] = Field(
+        default={"run": False, "bar_thickness": 0.3, "dpi": 1200},
+        title="Plotting options.",
     )
 
     def __post_init__(self) -> None:

--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -30,7 +30,7 @@ class Parameters:
     log_level: str = Field(default="info", title="Log level")
     cores: int = Field(default=2, title="Cores to run optimisation on in parallel.")
     width: int = Field(default=3, title="Width of structure.", ge=1)
-    height: int = Field(default=6, title="Height of structure.", ge=1)
+    height: int = Field(default=3, title="Height of structure.", ge=1)
     steps: float = Field(default=1.0, title="Steps to generate nodes", gt=0.0)
     stress_tensile: float = Field(default=1.0, title="Tensile stress.", ge=0.0)
     stress_compressive: float = Field(default=1.0, title="Compressive stress.", ge=0.0)

--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -36,7 +36,7 @@ class Parameters:
     stress_compressive: float = Field(default=1.0, title="Compressive stress.", ge=0.0)
     joint_cost: float = Field(default=0.0, title="Joint cost.", ge=0.0)
     loaded_points: npt.NDArray[np.int64] = Field(
-        default=np.asarray([[3, 3]]), title="Loaded Points."
+        default=np.asarray([[1, 0], [2, 0]]), title="Loaded Points."
     )
     load_direction: tuple[float, float] = Field(
         default=(0.0, -1.0), title="Loaded direction."

--- a/src/layopt/io.py
+++ b/src/layopt/io.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from argparse import Namespace
 from datetime import datetime
 from pathlib import Path
-from pkgutil import get_data
 from typing import Any
 
 import numpy as np
@@ -33,14 +32,8 @@ def write_config(args: Namespace | dict[str, Any] | Parameters | None) -> None:
     # If args is `Namespace` then we are writing config with 'layopt create_config' subcommand
     if isinstance(args, Namespace):
         output_dir = Path("./") if args.output_dir is None else Path(args.output_dir)
+        config = vars(Parameters())
         filename = "default_config.yaml" if args.filename is None else args.filename
-        try:
-            default_config = get_data(package="layopt", resource="default_config.yaml")
-            yaml = YAML(typ="safe")
-            config = yaml.load(default_config)
-        except FileNotFoundError as exc:
-            msg = "There was a problem loading 'default_config.yaml' try reinstalling LayOpt."
-            raise (FileNotFoundError(msg)) from exc
     # Otherwise we are writing after 'layopt optimise' and config is a dictionary, this won't have a 'filename'
     # key/value pair
     # ns-rse 2026-05-11 - This will be obsolete once we fully switch to the Parameters dataclass for holding configuration
@@ -49,7 +42,7 @@ def write_config(args: Namespace | dict[str, Any] | Parameters | None) -> None:
             Path("./") if args["output_dir"] is None else Path(args["output_dir"])
         )
         filename = f"config_{get_date_time(strftime='%Y-%m-%d-%H%M%S')}.yaml"
-        config = args
+        config = args  # type: ignore[assignment]
     # If we have 'Parameters' then configuration is stored as a dataclass and we again don't have 'filename' key/value pair
     elif isinstance(args, Parameters):
         output_dir = Path("./") if args.output_dir is None else Path(args.output_dir)  # type: ignore[redundant-expr]


### PR DESCRIPTION
Closes #140

- Reorders attributes of the Parameters class to reflect the existing structure of `default_config.yaml`
- Switches to using `vars(Parameters())` to get a dictionary of the configuration options and writing to disk using
  `layopt create-config`
- Sets the default solver in `Parameters.cvxpy["solver"] = "clarabel"`

---

Before submitting a Pull Request please check the following.

- [X] I have a MOSEK license.
- [X] Existing tests pass.
- [ ] ~Documentation has been updated and builds.~
- [X] Pre-commit checks pass.
- [ ] ~New functions/methods have typehints and docstrings.~
- [ ] ~New functions/methods have tests which check the intended behaviour is correct.~