### PR TITLE
Switching to `Structure` class in layopt module (Part 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,9 +121,12 @@ warn_unreachable = true
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 ignore_missing_imports = true
+# Disabled as not available in mypy pre-commit environment
+# plugins = "pydantic.mypy"
 
 [[tool.mypy.overrides]]
 module = [
+  "cvxpy.*",
   "layopt.*",
   "loguru.*",
   "numpy.*",
@@ -136,6 +139,8 @@ module = [
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 
+# [pydantic-mypy]
+# init_typed = True
 
 [tool.ruff]
 

--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -359,7 +359,7 @@ class Structure:
             self.parameters.load_direction,
         )
         self.potential_members = structure.calc_potential_members(
-            nodal_coords=self.nodes,
+            nodes=self.nodes,
             max_length=self.parameters.max_length,
             joint_cost=self.parameters.joint_cost,
             convex=self.convex,

--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -294,7 +294,9 @@ class Structure:
     active_load_cases : npt.NDArray[np.float64]
     """
 
-    parameters: Parameters
+    parameters: Parameters = Field(
+        title="Parameters for the structure and modelling", init=True
+    )
     bounding_coordinates: npt.NDArray[np.float64] = Field(
         title="Bounding coordinates", init=False
     )
@@ -371,7 +373,7 @@ class Structure:
         """
         return (
             f"Width             : {self.parameters.width}"
-            f"Width             : {self.parameters.height}"
+            f"Height            : {self.parameters.height}"
             f"Convex            : {self.convex}"
             f"Total nodes       : {len(self.nodes)}"
             f"Potential members : {len(self.potential_members)}"

--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -289,9 +289,14 @@ class Structure:
         Degrees of Freedom
     potential_members : npt.NDArray[np.float64]
         Potential members, with active points indicated.
+    active_members : npt.NDArray[np.float64]
+        Active members, a subset of `potential_members`, set after solving.
     primal_adaptivity : bool
         Indicator of primal adaptivity.
     active_load_cases : npt.NDArray[np.float64]
+        Active load cases.
+    active_pattern_loads : list[npt.NDArray[np.float64]]
+        A subset of `all_patterns` where load cases are active.
     """
 
     parameters: Parameters = Field(
@@ -310,9 +315,13 @@ class Structure:
     potential_members: npt.NDArray[np.float64] = Field(
         title="Potential members", init=False
     )
+    active_members: npt.NDArray[np.float64] = Field(title="Active members", init=False)
     primal_adaptivity: bool = Field(title="Primal adaptivity", init=False)
     active_load_cases: npt.NDArray[np.int32] = Field(
         title="Active load cases", init=False
+    )
+    active_pattern_loads: list[npt.NDArray[np.float64]] = Field(
+        title="Loaded points", init=False
     )
 
     def __post_init__(self) -> None:
@@ -357,10 +366,18 @@ class Structure:
             polygon=self.polygon,
             active_member_threshold=self.parameters.active_member_threshold,
         )
+        self.active_members = self.potential_members[
+            self.potential_members[:, 3] == True  # noqa: E712, pylint: disable=singleton-comparison
+        ]
         self.primal_adaptivity, self.active_load_cases = structure.primal_adaptivity(
             primal_method=self.parameters.primal_method,
             all_patterns_length=len(self.all_patterns),
         )
+        self.active_pattern_loads = [
+            self.all_patterns[k]
+            for k in range(len(self.all_patterns))
+            if self.active_load_cases[k] == 1
+        ]
 
     def __str__(self) -> str:
         """

--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -47,7 +47,7 @@ class Parameters:
     active_member_threshold: float = Field(
         default=1.5, title="Active member threshold", gt=0.0
     )
-    support_points: npt.NDArray[np.float32] = Field(
+    support_points: npt.NDArray[np.float64] = Field(
         default=np.asarray([[0, 0], [3, 3]]), title="Support Points."
     )
     member_area_filtering: float = Field(
@@ -295,7 +295,7 @@ class Structure:
     """
 
     parameters: Parameters
-    bounding_coordinates: list[list[int]] = Field(
+    bounding_coordinates: npt.NDArray[np.float64] = Field(
         title="Bounding coordinates", init=False
     )
     polygon: Polygon = Field(title="Polygon", init=False)
@@ -309,7 +309,7 @@ class Structure:
         title="Potential members", init=False
     )
     primal_adaptivity: bool = Field(title="Primal adaptivity", init=False)
-    active_load_cases: npt.NDArray[np.int64] = Field(
+    active_load_cases: npt.NDArray[np.int32] = Field(
         title="Active load cases", init=False
     )
 

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -27,8 +27,8 @@ from layopt.plotting import plot_truss
 
 
 def calc_eq_matrix_b(
-    nodal_coords: npt.NDArray[np.float64],
-    c_n: npt.NDArray[np.float64],
+    nodes: npt.NDArray[np.float64],
+    active_members: npt.NDArray[np.float64],
     dof: npt.NDArray[np.float64],
 ) -> sparse.coo_matrix:
     """
@@ -36,9 +36,9 @@ def calc_eq_matrix_b(
 
     Parameters
     ----------
-    nodal_coords : npt.NDArray[np.float64]
+    nodes : npt.NDArray[np.float64]
         Nodal coordinates.
-    c_n : npt.NDArray[np.float64]
+    active_members : npt.NDArray[np.float64]
         Active members.
     dof : npt.NDArray
         Degrees of freedom.
@@ -49,28 +49,32 @@ def calc_eq_matrix_b(
         Equilibrium matrix B.
     """
     try:
-        m, n1, n2 = len(c_n), c_n[:, 0].astype(int), c_n[:, 1].astype(int)
+        m, n1, n2 = (
+            len(active_members),
+            active_members[:, 0].astype(int),
+            active_members[:, 1].astype(int),
+        )
     except TypeError as e:
-        msg = "Missing 'c_n'"
+        msg = "Missing 'active_members'"
         raise TypeError(msg) from e
 
     try:
         length, x, y = (
-            c_n[:, 2],
-            nodal_coords[n2, 0] - nodal_coords[n1, 0],
-            nodal_coords[n2, 1] - nodal_coords[n1, 1],
+            active_members[:, 2],
+            nodes[n2, 0] - nodes[n1, 0],
+            nodes[n2, 1] - nodes[n1, 1],
         )
     except IndexError as e:
-        msg = f"{nodal_coords.shape=}, expected (2,{c_n.shape[1]})"
+        msg = f"{nodes.shape=}, expected (2,{active_members.shape[1]})"
         raise IndexError(msg) from e
     except TypeError as e:
-        msg = "Missing 'nodal_coords'"
+        msg = "Missing 'nodes'"
         raise TypeError(msg) from e
 
     try:
         d0, d1, d2, d3 = dof[n1 * 2], dof[n1 * 2 + 1], dof[n2 * 2], dof[n2 * 2 + 1]
     except IndexError as e:
-        msg = f"{dof.shape=}, expected ({(c_n.shape[0],)})"
+        msg = f"{dof.shape=}, expected ({(active_members.shape[0],)})"
         raise IndexError(msg) from e
     except TypeError as e:
         msg = "Missing 'dof'"
@@ -81,18 +85,13 @@ def calc_eq_matrix_b(
     )
     row_id = np.concatenate((n1 * 2, n1 * 2 + 1, n2 * 2, n2 * 2 + 1))
     col_id = np.concatenate((np.arange(m), np.arange(m), np.arange(m), np.arange(m)))
-    return sparse.coo_matrix((s, (row_id, col_id)), shape=(len(nodal_coords) * 2, m))
+    return sparse.coo_matrix((s, (row_id, col_id)), shape=(len(nodes) * 2, m))
 
 
 def solve(
-    nodal_coords: npt.NDArray[np.float64],
-    c_n: npt.NDArray[np.float64],
-    f: list[npt.NDArray[np.float64]],
-    dof: npt.NDArray[np.float64],
-    stress_tensile: float,
-    stress_compressive: float,
-    joint_cost: float,
-    solver: str,
+    structure: Structure,
+    active_members: npt.NDArray[np.float64],
+    active_pattern_loads: list[npt.NDArray[np.float64]],
 ) -> tuple[
     float,
     npt.NDArray[np.float64],
@@ -104,22 +103,12 @@ def solve(
 
     Parameters
     ----------
-    nodal_coords : npt.NDArray[np.float64]
-        Nodal coordinates.
-    c_n : npt.NDArray[np.float64]
+    structure : Structure
+        Object representing the structure.
+    active_members : npt.NDArray[np.float64]
         Active members.
-    f : list[npt.NDArray[np.float64]]
-        Load cases.
-    dof : npt.NDArray
-        Degrees of freedom.
-    stress_tensile : float
-        Tensile stress limit.
-    stress_compressive : float
-        Compressive stress limit.
-    joint_cost : float
-        Joint cost.
-    solver : str
-        CVXPY solver name.
+    active_pattern_loads : list[npt.NDArray[np.float64]]
+        Active pattern loads.
 
     Returns
     -------
@@ -128,33 +117,36 @@ def solve(
         ``area`` (member areas), ``forces`` (member forces) and ``deflections``
         (virtual deflections at degrees of freedom).
     """
-    member_cost = [col[2] + joint_cost for col in c_n]
-    eq_matrix_b = calc_eq_matrix_b(nodal_coords, c_n, dof)
+    member_cost = [col[2] + structure.parameters.joint_cost for col in active_members]
+    eq_matrix_b = calc_eq_matrix_b(
+        nodes=structure.nodes, active_members=active_members, dof=structure.dof
+    )
     eq_matrix_b = sparse.coo_matrix(
         (eq_matrix_b.data, (eq_matrix_b.row, eq_matrix_b.col)),
         shape=eq_matrix_b.shape,
     )
 
-    n_members = len(c_n)
+    # Assigned as used within for-loop
+    n_members = len(active_members)
+    # ns-rse 2026-07-17 - what does a represent here? number of non-negative active members?
     a = cvx.Variable(n_members, nonneg=True, name="a")
 
     q_vars = []
     eq_constraints = []
     other_constraints = []
-    for fk in f:
+    for active_pattern in active_pattern_loads:
         qi = cvx.Variable(n_members, name="q")
         q_vars.append(qi)
-        eq_con = eq_matrix_b @ qi == fk * dof
-        eq_constraints.append(eq_con)
+        eq_constraints.append(eq_matrix_b @ qi == active_pattern * structure.dof)
         other_constraints += [
-            # eq_matrix_b @ qi == fk * dof,                          # equilibrium
-            qi <= stress_compressive * a,  # compression limit
-            qi >= -stress_tensile * a,  # tension limit
+            # eq_matrix_b @ qi == active_pattern * dof,                          # equilibrium
+            qi <= structure.parameters.stress_compressive * a,  # compression limit
+            qi >= -structure.parameters.stress_tensile * a,  # tension limit
         ]
 
     objective = cvx.Minimize(member_cost @ a)
     problem = cvx.Problem(objective, eq_constraints + other_constraints)
-    problem.solve(solver)
+    problem.solve(structure.parameters.cvxpy["solver"])
 
     vol = 0.0 if problem.value is None else problem.value
     areas = np.zeros(n_members) if a.value is None else a.value
@@ -538,45 +530,41 @@ def trussopt(
     logger.info(f"    Total load patterns : {len(structure.all_patterns)}")
 
     vol = 1e9  # arbitrary large number to initialise
+    # Allows debugging to see if active_members has changed
+    previous_active_members = structure.potential_members[
+        structure.potential_members[:, 3] == True  # noqa: E712, pylint: disable=singleton-comparison
+    ]
     # Start the 'member adding' loop
     for itr in range(1, 100):
         last_volume = vol
-        # Get active members/parts of matrices \
-        c_n = structure.potential_members[structure.potential_members[:, 3] == True]  # noqa: E712, pylint: disable=singleton-comparison
 
-        # Get active pattern loads
-        f_active = [
+        # Get active pattern loads for current iteration
+        active_pattern_loads = [
             structure.all_patterns[k]
             for k in range(len(structure.all_patterns))
             if structure.active_load_cases[k] == 1
         ]
-
+        # Get active members/parts of matrices for current iteration
+        active_members = structure.potential_members[
+            structure.potential_members[:, 3] == True  # noqa: E712, pylint: disable=singleton-comparison
+        ]
+        logger.debug(
+            f"Itr {itr} active members changed? {active_members.shape != previous_active_members.shape}"
+        )
         # solve current reduced problem
         vol, filter_areas, filter_forces, u = solve(
-            structure.nodes,
-            c_n,
-            f_active,
-            structure.dof,
-            parameters.stress_tensile,
-            parameters.stress_compressive,
-            parameters.joint_cost,
-            parameters.cvxpy["solver"],
+            structure=structure,
+            active_members=active_members,
+            active_pattern_loads=active_pattern_loads,
         )
-        # We need to solve once so that we have valid values for `filter_areas ` which we then filter based on `fitler_level[s]`
-        # (rename to `filter_level` but need to check first if that is what we want to parallelise on or if it is
-        # `primal_method`).
-
-        # output
         if isinf(vol):
             logger.error("Infeasible problem detected")
             return None
         n_active = int(np.sum(structure.active_load_cases))
         # ns-rse 2026-03-23 : Could this perhaps be debugging?
         logger.info(
-            f"Iteration: {itr}, vol: {vol}, mems: {len(c_n)} active load cases:{n_active}/{len(structure.all_patterns)}"
+            f"Iteration: {itr}, vol: {vol}, mems: {len(active_members)} active load cases:{n_active}/{len(structure.all_patterns)}"
         )
-        # plot interim solutions (slow)
-        # plotTruss(nodal_coords, c_n, a, q, max(a) * 1e-2, "Itr:" + str(itr), extraPlot = activeDamageDef)
 
         # inner loop - adding of members based on dual violation
         # still need PMLcache? currently unused
@@ -605,7 +593,7 @@ def trussopt(
                 # Use equilibrium residual check
                 converged = stop_primal_violation_residual(
                     structure.nodes,
-                    c_n,
+                    active_members,
                     filter_forces,
                     structure.all_patterns,
                     structure.active_load_cases,
@@ -615,7 +603,7 @@ def trussopt(
                 # Use load factor LP
                 converged = stop_primal_violation_pattern(
                     structure.nodes,
-                    c_n,
+                    active_members,
                     filter_areas,
                     structure.all_patterns,
                     structure.active_load_cases,
@@ -625,7 +613,6 @@ def trussopt(
                     parameters.cvxpy["solver"],
                 )
             # ns-rse 2026-03-17 : leaves scope for 'converged' to not be assigned if `primal_method` never matches
-
             if not converged:  # pylint: disable=possibly-used-before-assignment
                 continue  # Cases added, keep iterating
             if n_added > 0:
@@ -635,6 +622,9 @@ def trussopt(
         if n_added == 0:
             break  # Converged
 
+    # Update the Structure active_members and active_pattern_loads
+    structure.active_members = active_members
+    structure.active_pattern_loads = active_pattern_loads
     final_vol = vol
     logger.info(f"Volume (filter_level = 1.0): {final_vol}")
     solve_end = time.process_time()
@@ -648,16 +638,11 @@ def trussopt(
         if filter_level != 1.0:
             logger.info(f"Solving for filter level : {filter_level}")
             keep = [area > (filter_level * max(filter_areas)) for area in filter_areas]
-            c_n = c_n[keep]
+            active_members = active_members[keep]
             final_vol, filter_areas, filter_forces, u = solve(
-                structure.nodes,
-                c_n,
-                f_active,
-                structure.dof,
-                parameters.stress_tensile,
-                parameters.stress_compressive,
-                parameters.joint_cost,
-                parameters.cvxpy["solver"],
+                structure=structure,
+                active_members=active_members,
+                active_pattern_loads=active_pattern_loads,
             )
             logger.info(f"Volume (filter_level = {filter_level}): {final_vol}")
         # Build dictionary of results (the final_vol changes if we have filtered above)
@@ -675,7 +660,7 @@ def trussopt(
             "load_small": parameters.load_small,
             "iterations": itr,
             "final_volume": final_vol,
-            "n_members_final": len(c_n),
+            "n_members_final": len(active_members),
             "n_nodes": len(structure.nodes),
             "n_ground_structure": len(structure.potential_members),
             "cpu_time_setup": setup_end - setup_start,
@@ -692,8 +677,8 @@ def trussopt(
             )
             if vol > 0:
                 _, _ = plot_truss(
-                    nodal_coords=structure.nodes,
-                    c_n=c_n,
+                    nodes=structure.nodes,
+                    active_members=active_members,
                     areas=filter_areas,
                     forces=filter_forces,
                     threshold=max(filter_areas) * parameters.member_area_filtering,

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -21,8 +21,7 @@ import pandas as pd
 from loguru import logger
 from scipy import sparse
 
-from layopt import structure
-from layopt.classes import Parameters
+from layopt.classes import Parameters, Structure
 from layopt.io import dict_to_df, get_date_time
 from layopt.plotting import plot_truss
 
@@ -525,90 +524,39 @@ def trussopt(
         the solved problem), and a data frame of results.
     """
     setup_start = time.process_time()
-    # Make domain
-    bounding_coordinates = np.asarray(
-        [
-            [0, 0],
-            [parameters.width, 0],
-            [parameters.width, parameters.height],
-            [0, parameters.height],
-        ]
-    )
-    poly = structure.make_polygon(bounding_coordinates)
-    convex = poly.convex_hull.area == poly.area
-    logger.debug(f"Domain created, convex? : {convex=}")
-
-    # Make nodes
-    nodal_coords: npt.NDArray[np.float64] = structure.create_nodes(
-        width=parameters.width, height=parameters.height, polygon=poly
-    )
-    logger.debug(f"Node coordinates :\n{nodal_coords=}")
-
-    # Default load point
-    if parameters.loaded_points is None:
-        parameters.loaded_points = structure.calc_default_loaded_points(
-            width=parameters.width, height=parameters.height
-        )
-        logger.info(
-            f"Loaded points not provided, calculated as : {parameters.loaded_points=}"
-        )
-    # Calculate support conditions/degrees of freedom
-    dof = structure.support_conditions(
-        nodal_coords=nodal_coords, support_points=parameters.support_points
-    )
-    logger.debug(f"Degrees of Freedom : {dof=}")
-    # Generate all pattern loads
-    # ns-rse 2026-03-17 : Unused return arguments but may combine all_patterns and pattern_descriptions to dict
-    # all_patterns, base_load, pattern_descriptions = make_pattern_loads(
-    # ns-rse 2026-05-13 - loaded_points and load_direction are proposed to be attributes of CaseFamily
-    all_patterns, _, _ = structure.make_pattern_loads(
-        nodal_coords,
-        parameters.loaded_points,
-        parameters.load_large,
-        parameters.load_small,
-        parameters.load_direction,
-    )
-
-    # Create the 'ground structure'
-    potential_members = structure.calc_potential_members(
-        nodal_coords=nodal_coords,
-        max_length=parameters.max_length,
-        joint_cost=parameters.joint_cost,
-        convex=convex,
-        polygon=poly,
-        active_member_threshold=parameters.active_member_threshold,
-    )
-    # Primal adaptivity: start with base load case only ####
-    primal_adaptivity, active_load_cases = structure.primal_adaptivity(
-        primal_method=parameters.primal_method, all_patterns_length=len(all_patterns)
-    )
-
+    # Instantiate the structure
+    # ns-rse 2026-07-16 : unclear why mypy complains about parameters its the only required argument in the class
+    # definition
+    structure = Structure(parameters=parameters)  # type: ignore[call-arg]
+    logger.debug(f"Domain created, convex? : {structure.convex=}")
+    logger.debug(f"Node coordinates :\n{structure.nodes=}")
+    logger.debug(f"Degrees of Freedom : {structure.dof=}")
     setup_end = time.process_time()
     logger.info(f"Setup took {setup_end - setup_start!s}")
-    logger.info(f"    Nodes               : {len(nodal_coords)}")
-    logger.info(f"    Members             : {len(potential_members)}")
-    logger.info(f"    Total load patterns : {len(all_patterns)}")
+    logger.info(f"    Nodes               : {len(structure.nodes)}")
+    logger.info(f"    Members             : {len(structure.potential_members)}")
+    logger.info(f"    Total load patterns : {len(structure.all_patterns)}")
 
     vol = 1e9  # arbitrary large number to initialise
     # Start the 'member adding' loop
     for itr in range(1, 100):
         last_volume = vol
-        # Get active members/parts of matrices
-        c_n = potential_members[potential_members[:, 3] == True]  # noqa: E712, pylint: disable=singleton-comparison
+        # Get active members/parts of matrices \
+        c_n = structure.potential_members[structure.potential_members[:, 3] == True]  # noqa: E712, pylint: disable=singleton-comparison
 
         # Get active pattern loads
         f_active = [
-            all_patterns[k]
-            for k in range(len(all_patterns))
-            if active_load_cases[k] == 1
+            structure.all_patterns[k]
+            for k in range(len(structure.all_patterns))
+            if structure.active_load_cases[k] == 1
         ]
 
         # solve current reduced problem
         vol, filter_areas, filter_forces, u = solve(
-            nodal_coords,
+            structure.nodes,
             c_n,
             f_active,
-            dof,
+            structure.dof,
             parameters.stress_tensile,
             parameters.stress_compressive,
             parameters.joint_cost,
@@ -622,10 +570,10 @@ def trussopt(
         if isinf(vol):
             logger.error("Infeasible problem detected")
             return None
-        n_active = int(np.sum(active_load_cases))
+        n_active = int(np.sum(structure.active_load_cases))
         # ns-rse 2026-03-23 : Could this perhaps be debugging?
         logger.info(
-            f"Iteration: {itr}, vol: {vol}, mems: {len(c_n)} active load cases:{n_active}/{len(all_patterns)}"
+            f"Iteration: {itr}, vol: {vol}, mems: {len(c_n)} active load cases:{n_active}/{len(structure.all_patterns)}"
         )
         # plot interim solutions (slow)
         # plotTruss(nodal_coords, c_n, a, q, max(a) * 1e-2, "Itr:" + str(itr), extraPlot = activeDamageDef)
@@ -634,9 +582,9 @@ def trussopt(
         # still need PMLcache? currently unused
         # PMLcache = np.copy(PML[:,3])
         n_added = stop_violation(
-            nodal_coords,
-            potential_members,
-            dof,
+            structure.nodes,
+            structure.potential_members,
+            structure.dof,
             parameters.stress_tensile,
             parameters.stress_compressive,
             u,
@@ -646,32 +594,32 @@ def trussopt(
             continue  # small vol decrease = member adding close to convergence
 
         # outer loop - adding of pattern load cases based on primal violation
-        # if stopPrimalViolationPattern(nodal_coords, c_n, a, all_patterns, active_load_cases, dof, st, sc):
+        # if stopPrimalViolationPattern(nodal_coords, c_n, a, structure.all_patterns, structure.active_load_cases, dof, st, sc):
         #     if numAdded > 0: # only fully terminate when no members violate
         #         continue
         #     else:
         #         break
 
-        if primal_adaptivity:
+        if structure.primal_adaptivity:
             if parameters.primal_method == "residual":
                 # Use equilibrium residual check
                 converged = stop_primal_violation_residual(
-                    nodal_coords,
+                    structure.nodes,
                     c_n,
                     filter_forces,
-                    all_patterns,
-                    active_load_cases,
-                    dof,
+                    structure.all_patterns,
+                    structure.active_load_cases,
+                    structure.dof,
                 )
             elif parameters.primal_method == "load_factor":
                 # Use load factor LP
                 converged = stop_primal_violation_pattern(
-                    nodal_coords,
+                    structure.nodes,
                     c_n,
                     filter_areas,
-                    all_patterns,
-                    active_load_cases,
-                    dof,
+                    structure.all_patterns,
+                    structure.active_load_cases,
+                    structure.dof,
                     parameters.stress_tensile,
                     parameters.stress_compressive,
                     parameters.cvxpy["solver"],
@@ -692,7 +640,7 @@ def trussopt(
     solve_end = time.process_time()
     logger.info("Solve took " + str(solve_end - setup_end))
     logger.info(
-        f"Active patterns: {int(np.sum(active_load_cases))}/{len(all_patterns)}"
+        f"Active patterns: {int(np.sum(structure.active_load_cases))}/{len(structure.all_patterns)}"
     )
     results = {}
     for filter_level in parameters.filter_levels:
@@ -702,10 +650,10 @@ def trussopt(
             keep = [area > (filter_level * max(filter_areas)) for area in filter_areas]
             c_n = c_n[keep]
             final_vol, filter_areas, filter_forces, u = solve(
-                nodal_coords,
+                structure.nodes,
                 c_n,
                 f_active,
-                dof,
+                structure.dof,
                 parameters.stress_tensile,
                 parameters.stress_compressive,
                 parameters.joint_cost,
@@ -721,15 +669,15 @@ def trussopt(
             "width": parameters.width,
             "height": parameters.height,
             "n_load_points": len(parameters.loaded_points),
-            "n_patterns_total": len(all_patterns),
-            "n_patterns_active": int(np.sum(active_load_cases)),
+            "n_patterns_total": len(structure.all_patterns),
+            "n_patterns_active": int(np.sum(structure.active_load_cases)),
             "load_large": parameters.load_large,
             "load_small": parameters.load_small,
             "iterations": itr,
             "final_volume": final_vol,
             "n_members_final": len(c_n),
-            "n_nodes": len(nodal_coords),
-            "n_ground_structure": len(potential_members),
+            "n_nodes": len(structure.nodes),
+            "n_ground_structure": len(structure.potential_members),
             "cpu_time_setup": setup_end - setup_start,
             "cpu_time_solve": solve_end - setup_end,
             "primal_method": parameters.primal_method,
@@ -744,7 +692,7 @@ def trussopt(
             )
             if vol > 0:
                 _, _ = plot_truss(
-                    nodal_coords=nodal_coords,
+                    nodal_coords=structure.nodes,
                     c_n=c_n,
                     areas=filter_areas,
                     forces=filter_forces,
@@ -759,7 +707,7 @@ def trussopt(
         logger.info(f"Plotting took {time.process_time() - solve_end!s}")
 
     member_areas_filtered = member_area_filtering(
-        active_indices=np.where(potential_members[:, 3])[0],
+        active_indices=np.where(structure.potential_members[:, 3])[0],
         filter_areas=filter_areas,
         filtering_threshold=parameters.member_area_filtering,
     )

--- a/src/layopt/plotting.py
+++ b/src/layopt/plotting.py
@@ -19,8 +19,8 @@ plt.rcParams["figure.max_open_warning"] = 0
 
 
 def plot_truss(
-    nodal_coords: npt.NDArray[np.float64],
-    c_n: npt.NDArray[np.float64],
+    nodes: npt.NDArray[np.float64],
+    active_members: npt.NDArray[np.float64],
     areas: npt.NDArray[np.float64],
     forces: list[npt.NDArray[np.float64]],
     threshold: float,
@@ -35,9 +35,9 @@ def plot_truss(
 
     Parameters
     ----------
-    nodal_coords : npt.NDArray
+    nodes : npt.NDArray
         Nodal coordinates.
-    c_n : npt.NDArray[np.float64]
+    active_members : npt.NDArray[np.float64]
         Active members.
     areas : npt.NDArray[np.float64]
         Member areas.
@@ -82,7 +82,7 @@ def plot_truss(
                 0,
                 min(max(-forces[0][i] / areas[i], 0), 1),
             )
-        pos = nodal_coords[c_n[i, [0, 1]].astype(int), :]
+        pos = nodes[active_members[i, [0, 1]].astype(int), :]
         ax.plot(
             pos[:, 0],
             pos[:, 1],
@@ -100,8 +100,8 @@ def plot_truss(
 
 
 def plot_all_cases(
-    nodal_coords: npt.NDArray[np.float64],
-    c_n: npt.NDArray[np.float64],
+    nodes: npt.NDArray[np.float64],
+    active_members: npt.NDArray[np.float64],
     areas: npt.NDArray[np.float64],
     forces: list[npt.NDArray[np.float64]],
     threshold: float,
@@ -112,9 +112,9 @@ def plot_all_cases(
 
     Parameters
     ----------
-    nodal_coords : npt.NDArray
+    nodes : npt.NDArray
         Nodal coordinates.
-    c_n : npt.NDArray
+    active_members : npt.NDArray
         Active members.
     areas : npt.NDArray
         Member areas.
@@ -127,8 +127,8 @@ def plot_all_cases(
     """
     for k in enumerate(forces):
         plot_truss(
-            nodal_coords=nodal_coords,
-            c_n=c_n,
+            nodes=nodes,
+            active_members=active_members,
             areas=areas,
             forces=[forces[k]],  # type: ignore[call-overload]
             threshold=threshold,

--- a/src/layopt/structure.py
+++ b/src/layopt/structure.py
@@ -250,7 +250,7 @@ def primal_adaptivity(
         A tuple of a boolean for ``primal_method`` and the associated ``active_load_cases``.
     """
     if primal_method in {"residual", "load_factor"}:
-        active_load_cases = np.zeros(all_patterns_length, dtype=int)
+        active_load_cases = np.zeros(all_patterns_length, dtype=np.int32)
         active_load_cases[0] = 1  # Base case = all large loads
         return (True, active_load_cases)
-    return (False, np.ones(all_patterns_length, dtype=int))
+    return (False, np.ones(all_patterns_length, dtype=np.int32))

--- a/src/layopt/structure.py
+++ b/src/layopt/structure.py
@@ -181,7 +181,7 @@ def make_pattern_loads(
 
 
 def calc_potential_members(
-    nodal_coords: npt.NDArray,
+    nodes: npt.NDArray[np.float64],
     max_length: float,
     joint_cost: float,
     convex: bool,
@@ -193,7 +193,7 @@ def calc_potential_members(
 
     Parameters
     ----------
-    nodal_coords : npt.NDArray,
+    nodes : npt.NDArray[np.float64],
         Node coordinates.
     max_length : int | float,
         Maximum length.
@@ -209,18 +209,18 @@ def calc_potential_members(
     Returns
     -------
     npt.NDArray[np.float64]
-        Array of ground structure coordinates.
+        Array of node start, end, length and active status with overlapping members and members `> max_length` removed.
     """
     potential_members = []
-    for i, j in itertools.combinations(range(len(nodal_coords)), 2):
+    for i, j in itertools.combinations(range(len(nodes)), 2):
         dx, dy = (
-            abs(nodal_coords[i][0] - nodal_coords[j][0]),
-            abs(nodal_coords[i][1] - nodal_coords[j][1]),
+            abs(nodes[i][0] - nodes[j][0]),
+            abs(nodes[i][1] - nodes[j][1]),
         )
         length = np.sqrt(dx**2 + dy**2)
         # Remove overlapping members, or members longer than maxLength
         if (length < max_length and gcd(int(dx), int(dy)) == 1) or joint_cost != 0:
-            seg = [] if convex else LineString([nodal_coords[i], nodal_coords[j]])
+            seg = [] if convex else LineString([nodes[i], nodes[j]])
             if convex or polygon.contains(seg) or polygon.boundary.contains(seg):
                 # Mark as active
                 if length <= active_member_threshold:
@@ -233,7 +233,7 @@ def calc_potential_members(
 
 def primal_adaptivity(
     primal_method: str, all_patterns_length: int
-) -> tuple[bool, npt.NDArray[np.int32]]:
+) -> tuple[bool, npt.NDArray[np.bool]]:
     """
     Derive primal method and active load cases. Start with base load for cases only.
 
@@ -246,11 +246,11 @@ def primal_adaptivity(
 
     Returns
     -------
-    tuple[bool, npt.NDArray[np.int32]]
+    tuple[bool, npt.NDArray[np.bool]]
         A tuple of a boolean for ``primal_method`` and the associated ``active_load_cases``.
     """
     if primal_method in {"residual", "load_factor"}:
-        active_load_cases = np.zeros(all_patterns_length, dtype=np.int32)
+        active_load_cases = np.zeros(all_patterns_length, dtype=np.bool)
         active_load_cases[0] = 1  # Base case = all large loads
         return (True, active_load_cases)
-    return (False, np.ones(all_patterns_length, dtype=np.int32))
+    return (False, np.ones(all_patterns_length, dtype=np.bool))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,13 @@ from layopt.classes import Parameters
 
 
 @pytest.fixture
-def nodal_coords() -> npt.NDArray[np.int32]:
+def nodes() -> npt.NDArray[np.int32]:
     """Coordinates for simple test."""
     return np.array([[x, y] for y in range(2) for x in range(5)])
 
 
 @pytest.fixture
-def c_n():
+def active_members():
     """Active members."""
     return np.array(
         [
@@ -36,10 +36,10 @@ def c_n():
 
 @pytest.fixture
 def input_one_by_one() -> dict[str, npt.NDArray[np.float32]]:
-    """``nodal_coords``, ``c_n`` and ``dof`` for a 1x1 structure."""
+    """``nodes``, ``active_members`` and ``dof`` for a 1x1 structure."""
     return {
-        "nodal_coords": np.asarray([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]),
-        "c_n": np.asarray(
+        "nodes": np.asarray([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]),
+        "active_members": np.asarray(
             [
                 [0.0, 1.0, 1.0, True],
                 [0.0, 2.0, 1.0, True],
@@ -55,9 +55,9 @@ def input_one_by_one() -> dict[str, npt.NDArray[np.float32]]:
 
 @pytest.fixture
 def input_two_by_two() -> dict[str, npt.NDArray[np.float32]]:
-    """``nodal_coords``, ``c_n`` and ``dof`` for a 2x2 structure."""
+    """``nodes``, ``active_members`` and ``dof`` for a 2x2 structure."""
     return {
-        "nodal_coords": np.asarray(
+        "nodes": np.asarray(
             [
                 [0.0, 0.0],
                 [1.0, 0.0],
@@ -70,7 +70,7 @@ def input_two_by_two() -> dict[str, npt.NDArray[np.float32]]:
                 [2.0, 2.0],
             ]
         ),
-        "c_n": np.asarray(
+        "active_members": np.asarray(
             [
                 [0.0, 1.0, 1.0, False],
                 [0.0, 3.0, 1.0, True],
@@ -123,9 +123,9 @@ def input_two_by_two() -> dict[str, npt.NDArray[np.float32]]:
 
 @pytest.fixture
 def input_three_by_six() -> dict[str, npt.NDArray[np.float32]]:
-    """``nodal_coords``, ``c_n`` and ``dof`` for a 3x6 structure."""
+    """``nodes``, ``active_members`` and ``dof`` for a 3x6 structure."""
     return {
-        "nodal_coords": np.asarray(
+        "nodes": np.asarray(
             [
                 [0.0, 0.0],
                 [1.0, 0.0],
@@ -157,7 +157,7 @@ def input_three_by_six() -> dict[str, npt.NDArray[np.float32]]:
                 [3.0, 6.0],
             ]
         ),
-        "c_n": np.asarray(
+        "active_members": np.asarray(
             [
                 [0.0, 1.0, 1.0, True],
                 [0.0, 4.0, 1.0, True],
@@ -450,9 +450,11 @@ def plotting_data_one_by_one() -> dict[str, npt.NDArray[np.float32]]:
     """Relevant plotting data for 1x1 example."""
     return {
         "areas": np.asarray([70.71067812, 50.0]),
-        "c_n": np.asarray([[0.0, 3.0, 1.41421356, 1.0], [2.0, 3.0, 1.0, 1.0]]),
+        "active_members": np.asarray(
+            [[0.0, 3.0, 1.41421356, 1.0], [2.0, 3.0, 1.0, 1.0]]
+        ),
         "forces": [np.asarray([-70.71067812, 50.0])],
-        "nodal_coords": np.asarray([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]),
+        "nodes": np.asarray([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]),
         "threshold": 0.07071067811522617,
     }
 
@@ -472,7 +474,7 @@ def plotting_data_two_by_two() -> dict[str, npt.NDArray[np.float32]]:
                 31.5985,
             ]
         ),
-        "c_n": np.asarray(
+        "active_members": np.asarray(
             [
                 [0.0, 4.0, 1.41421, 1.0],
                 [0.0, 5.0, 2.23607, 1.0],
@@ -496,7 +498,7 @@ def plotting_data_two_by_two() -> dict[str, npt.NDArray[np.float32]]:
                 ]
             )
         ],
-        "nodal_coords": np.asarray(
+        "nodes": np.asarray(
             [
                 [0.0, 0.0],
                 [1.0, 0.0],
@@ -527,7 +529,7 @@ def plotting_data_three_by_six_short_cantilever() -> dict[str, npt.NDArray[np.fl
                 35.35533906,
             ]
         ),
-        "c_n": np.asarray(
+        "active_members": np.asarray(
             [
                 [0.0, 5.0, 1.41421356, 1.0],
                 [5.0, 10.0, 1.41421356, 1.0],
@@ -549,7 +551,7 @@ def plotting_data_three_by_six_short_cantilever() -> dict[str, npt.NDArray[np.fl
                 ]
             )
         ],
-        "nodal_coords": np.asarray(
+        "nodes": np.asarray(
             [
                 [0.0, 0.0],
                 [1.0, 0.0],

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -210,8 +210,10 @@ def test_parameters_exceptions(config: ValidationError) -> None:
                 "dof": np.asarray([0.0, 0.0]),
                 "all_patterns": np.asarray([[0, 0]]),
                 "potential_members": np.empty((0, 4)),
+                "active_members": np.empty((0, 4), dtype=np.float64),
                 "primal_adaptivity": True,
                 "active_load_cases": np.asarray([0]),
+                "active_pattern_loads": np.asarray([]),
             },
             id="1x1",
         ),
@@ -231,8 +233,10 @@ def test_parameters_exceptions(config: ValidationError) -> None:
                 "dof": np.asarray([0.0, 0.0]),
                 "all_patterns": np.asarray([[0, 0]]),
                 "potential_members": np.empty((0, 4)),
+                "active_members": np.empty((0, 4), dtype=np.float64),
                 "primal_adaptivity": True,
                 "active_load_cases": np.asarray([0]),
+                "active_pattern_loads": np.asarray([]),
             },
             id="2x2",
         ),
@@ -252,8 +256,10 @@ def test_parameters_exceptions(config: ValidationError) -> None:
                 "dof": np.asarray([0.0, 0.0]),
                 "all_patterns": np.asarray([[0, 0]]),
                 "potential_members": np.empty((0, 4)),
+                "active_members": np.empty((0, 4), dtype=np.float64),
                 "primal_adaptivity": True,
                 "active_load_cases": np.asarray([0]),
+                "active_pattern_loads": np.asarray([]),
             },
             id="18x4 spanning",
         ),
@@ -318,7 +324,13 @@ def test_structure_post_init(
     np.testing.assert_array_equal(
         structure.potential_members, expected_attributes["potential_members"]
     )
+    np.testing.assert_array_equal(
+        structure.active_members, expected_attributes["active_members"]
+    )
     assert structure.primal_adaptivity == expected_attributes["primal_adaptivity"]
     np.testing.assert_array_equal(
         structure.active_load_cases, expected_attributes["active_load_cases"]
+    )
+    np.testing.assert_array_equal(
+        structure.active_pattern_loads, expected_attributes["active_pattern_loads"]
     )

--- a/tests/test_layopt.py
+++ b/tests/test_layopt.py
@@ -69,8 +69,8 @@ def test_calc_eq_matrix_b(
     """Test for calc_eq_matrix_b()."""
     structure = request.getfixturevalue(structure_fixture)
     result = layopt.calc_eq_matrix_b(
-        nodal_coords=structure["nodal_coords"],
-        c_n=structure["c_n"],
+        nodes=structure["nodal_coords"],
+        active_members=structure["c_n"],
         dof=structure["dof"],
     )
     assert result.coords == snapshot
@@ -79,7 +79,7 @@ def test_calc_eq_matrix_b(
 
 
 @pytest.mark.parametrize(
-    ("nodal_coords", "c_n", "dof", "expected"),
+    ("nodes", "active_members", "dof", "expected"),
     [
         pytest.param(
             np.asarray([[0.0, 0.0], [1.0, 0.0]]),
@@ -171,14 +171,14 @@ def test_calc_eq_matrix_b(
     ],
 )
 def test_calc_eq_matrix_b_errors(
-    nodal_coords: npt.NDArray[np.float64],
-    c_n: npt.NDArray[np.float64],
+    nodes: npt.NDArray[np.float64],
+    active_members: npt.NDArray[np.float64],
     dof: npt.NDArray[np.float64],
     expected,
 ) -> None:
     """Test for calc_eq_matrix_b()."""
     with pytest.raises(expected):
-        layopt.calc_eq_matrix_b(nodal_coords=nodal_coords, c_n=c_n, dof=dof)
+        layopt.calc_eq_matrix_b(nodes=nodes, active_members=active_members, dof=dof)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_layopt.py
+++ b/tests/test_layopt.py
@@ -69,8 +69,8 @@ def test_calc_eq_matrix_b(
     """Test for calc_eq_matrix_b()."""
     structure = request.getfixturevalue(structure_fixture)
     result = layopt.calc_eq_matrix_b(
-        nodes=structure["nodal_coords"],
-        active_members=structure["c_n"],
+        nodes=structure["nodes"],
+        active_members=structure["active_members"],
         dof=structure["dof"],
     )
     assert result.coords == snapshot
@@ -95,7 +95,7 @@ def test_calc_eq_matrix_b(
             ),
             np.asarray([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0]),
             IndexError,
-            id="nodal_coords too short",
+            id="nodes too short",
         ),
         pytest.param(
             None,
@@ -111,7 +111,7 @@ def test_calc_eq_matrix_b(
             ),
             np.asarray([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0]),
             TypeError,
-            id="nodal_coords is None",
+            id="nodes is None",
         ),
         pytest.param(
             np.asarray([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]),
@@ -124,7 +124,7 @@ def test_calc_eq_matrix_b(
             ),
             np.asarray([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0]),
             IndexError,
-            id="c_n too short",
+            id="active_members too short",
             marks=pytest.mark.skip(
                 reason="no IndexError as serves as basis for subsetting other arrays"
             ),
@@ -134,7 +134,7 @@ def test_calc_eq_matrix_b(
             None,
             np.asarray([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0]),
             TypeError,
-            id="c_n is None",
+            id="active_members is None",
         ),
         pytest.param(
             np.asarray([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]),
@@ -465,8 +465,8 @@ def test_member_area_filtering(
     ],
 )
 def test_stop_primal_violation(
-    nodal_coords: npt.NDArray[np.float64],
-    c_n: npt.NDArray[np.float64],
+    nodes: npt.NDArray[np.float64],
+    active_members: npt.NDArray[np.float64],
     all_patterns: npt.NDArray[np.float64],
     active_load_cases: npt.NDArray[np.float64],
     areas: npt.NDArray[np.float64],
@@ -478,8 +478,8 @@ def test_stop_primal_violation(
 ) -> None:
     """Test for convergence based on whether all load cases active."""
     actual_converge = layopt.stop_primal_violation_pattern(
-        nodal_coords,
-        c_n,
+        nodes,
+        active_members,
         areas,
         all_patterns,
         active_load_cases,
@@ -532,8 +532,8 @@ def test_stop_violation(
     """Test that the function sets members active correctly and returns non-negative integer."""
     structure = request.getfixturevalue(structure_fixture)
     actual_num_added = layopt.stop_violation(
-        nodal_coords=structure["nodal_coords"],
-        potential_members=structure["c_n"],
+        nodal_coords=structure["nodes"],
+        potential_members=structure["active_members"],
         dof=structure["dof"],
         stress_tensile=stress_tensile,
         stress_compressive=stress_compressive,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -56,8 +56,8 @@ def test_plot_truss(
     """Test for ``plotting.plot_truss()``."""
     plotting_data = request.getfixturevalue(plotting_data_fixture)
     fig, _ = plotting.plot_truss(
-        nodes=plotting_data["nodal_coords"],
-        active_members=plotting_data["c_n"],
+        nodes=plotting_data["nodes"],
+        active_members=plotting_data["active_members"],
         areas=plotting_data["areas"],
         forces=plotting_data["forces"],
         threshold=plotting_data["threshold"],

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -56,8 +56,8 @@ def test_plot_truss(
     """Test for ``plotting.plot_truss()``."""
     plotting_data = request.getfixturevalue(plotting_data_fixture)
     fig, _ = plotting.plot_truss(
-        nodal_coords=plotting_data["nodal_coords"],
-        c_n=plotting_data["c_n"],
+        nodes=plotting_data["nodal_coords"],
+        active_members=plotting_data["c_n"],
         areas=plotting_data["areas"],
         forces=plotting_data["forces"],
         threshold=plotting_data["threshold"],

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -182,10 +182,9 @@ def test_support_conditions(
             id="3 load points (2^3)",
         ),
     ],
-    ids=["1_point", "2_points", "3_points"],
 )
 def test_make_pattern_loads_num_load_patterns(
-    nodal_coords: npt.NDArray[np.float64],
+    nodes: npt.NDArray[np.float64],
     load_large: float,
     load_small: float,
     load_direction_default: tuple[float, float],
@@ -194,7 +193,7 @@ def test_make_pattern_loads_num_load_patterns(
 ):
     """Test for ``structure.make_pattern_loads()``."""
     all_patterns, _, _ = structure.make_pattern_loads(
-        nodal_coords, loaded_points, load_large, load_small, load_direction_default
+        nodes, loaded_points, load_large, load_small, load_direction_default
     )
     assert len(all_patterns) == expected_pattern_count
 
@@ -408,7 +407,7 @@ def test_make_pattern_loads_num_load_patterns(
     ],
 )
 def test_make_pattern_loads_load_directions_and_node_snapping(
-    nodal_coords: npt.NDArray[np.float64],
+    nodes: npt.NDArray[np.float64],
     load_large: float,
     load_small: float,
     loaded_points: npt.NDArray[np.float64],
@@ -419,7 +418,7 @@ def test_make_pattern_loads_load_directions_and_node_snapping(
 ):
     """Test vertical loads, horizontal loads, and snapping to nearest nodes."""
     all_patterns, base_load, pattern_description = structure.make_pattern_loads(
-        nodal_coords, loaded_points, load_large, load_small, direction
+        nodes, loaded_points, load_large, load_small, direction
     )
     assert len(all_patterns) == expected_pattern_count
     np.testing.assert_equal(all_patterns, expected_patterns)
@@ -448,7 +447,7 @@ def test_make_pattern_loads_load_directions_and_node_snapping(
     ],
 )
 def test_make_pattern_loads_zero_load_points_error(
-    nodal_coords: npt.NDArray[np.float64],
+    nodes: npt.NDArray[np.float64],
     loaded_points: Any,
     error: str,
     msg: str,
@@ -456,7 +455,7 @@ def test_make_pattern_loads_zero_load_points_error(
     """Test that 0 load points raises AssertionError from ``structure.make_pattern_loads()``."""
     with pytest.raises(error, match=msg):
         structure.make_pattern_loads(
-            nodal_coords=nodal_coords,
+            nodal_coords=nodes,
             loaded_points=loaded_points,
             load_large=3.75,
             load_small=0.204,
@@ -465,7 +464,7 @@ def test_make_pattern_loads_zero_load_points_error(
 
 
 @pytest.mark.parametrize(
-    ("nodal_coords", "max_length", "joint_cost", "convex", "polygon", "expected"),
+    ("nodes", "max_length", "joint_cost", "convex", "polygon", "expected"),
     [
         pytest.param(
             np.asarray([[0, 0], [0, 1], [1, 0], [1, 1]]),
@@ -501,7 +500,7 @@ def test_make_pattern_loads_zero_load_points_error(
     ],
 )
 def test_calc_potential_members(
-    nodal_coords: npt.NDArray[np.int64],
+    nodes: npt.NDArray[np.int64],
     max_length: float,
     joint_cost: float,
     convex: bool,
@@ -511,7 +510,7 @@ def test_calc_potential_members(
     """Test for ``structure.calc_potential_members()``."""
     np.testing.assert_array_equal(
         structure.calc_potential_members(
-            nodal_coords=nodal_coords,
+            nodes=nodes,
             max_length=max_length,
             joint_cost=joint_cost,
             convex=convex,


### PR DESCRIPTION
**NB** This is a stacked pull request and should be merged after #148 

Switches the `layopt.solver()` function to use the `Structure` class.

- `c_n` > `active_members` (because of comment at [596](https://github.com/ICAIR-Sheffield/LayOpt/blob/99d4ae4d721238a1546c1eef2c389c36d546c9fd/src/layopt/layopt.py#L596) and `nodal_coords` > `nodes`[^1] within `layopt.solver()` and `layopt.trussopt()` - improves
  expressiveness of the code and   makes it easier to understand.
- Rename parameters in plotting to align with above.
- make initial calculation of `active_pattern_loads` (nee `f_active`) and `active_members` during
  `Structure.__post_init__()`. These chage during the `for iter in range(1, 100)` which adds members (although I've not
  yet been able to work out where or how). After this loop has ended the attributes are updated. Tests for the values
  are added to the `test_classes()::test_structure` but they aren't very meaningful as both attributes are empty arrays
  for the current parameterisation.
- Rename parameters to `layopt.calc_eq_matrix_b()`
- Use named arguments in functions rather than positional, its more explicit and lets users/future developers know what
  is being passed where (I think the only real cases for using positional arguments is where they match names _exactly_
  or when using `**kwargs` to unpack). The Zen of Python (item 2) - "Explicit is better than implicit"
  (https://peps.python.org/pep-0020/)

---

Before submitting a Pull Request please check the following.

- [X] I have a MOSEK license.
- [X] Existing tests pass.
- [ ] ~Documentation has been updated and builds.~
- [X] Pre-commit checks pass.
- [ ] ~New functions/methods have typehints and docstrings.~
- [ ] ~New functions/methods have tests which check the intended behaviour is correct.~


[^1]: "nodal" means relating to a node, "coords" indicates they are the coordinates, it seemed clearer to just refer to them as the `nodes`.