### PR TITLE
fix: Remove default in csv_filename argument

### DIFF
--- a/.github/workflows/build_mkdocs.yaml
+++ b/.github/workflows/build_mkdocs.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v9
         with:
           activate-environment: true
           python-version: 3.13

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v9
         with:
           activate-environment: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v9
         with:
           activate-environment: true
           python-version: ${{ matrix.python-version }}

--- a/src/layopt/entry_point.py
+++ b/src/layopt/entry_point.py
@@ -180,7 +180,6 @@ def layopt_parser() -> arg.ArgumentParser:
         "--csv-filename",
         dest="csv_filename",
         type=str,
-        default="results.csv",
         required=False,
         help="File to save results to. Defaults to 'results_<YYYY-MM-DD-hhmmss>.csv'.",
     )


### PR DESCRIPTION
Closes #156

Having a default set for the `--csv-filename` argument was clobbering the values set in users custom configurations.

We will only ever need `--csv-filename` if a user explictly sets it...and now we know that it will take precedence!

Thanks for reporting this @fisher568

---

Before submitting a Pull Request please check the following.

- [X] I have a MOSEK license.
- [X] Existing tests pass.
- [X] Documentation has been updated and builds.
- [X] Pre-commit checks pass.
- [ ] ~New functions/methods have typehints and docstrings.~
- [ ] ~New functions/methods have tests which check the intended behaviour is correct.~