### PR TITLE
fix: Remove default in csv_filename argument

### DIFF
--- a/src/layopt/entry_point.py
+++ b/src/layopt/entry_point.py
@@ -50,7 +50,6 @@ def layopt_parser() -> arg.ArgumentParser:
         "-l",
         "--log-level",
         dest="log_level",
-        default="info",
         type=str,
         required=False,
         help="Set verbosity of logging, options (least verbose to most) are 'error', 'warning', 'info', 'error', 'debug'.",

--- a/src/layopt/entry_point.py
+++ b/src/layopt/entry_point.py
@@ -180,7 +180,6 @@ def layopt_parser() -> arg.ArgumentParser:
         "--csv-filename",
         dest="csv_filename",
         type=str,
-        default="results.csv",
         required=False,
         help="File to save results to. Defaults to 'results_<YYYY-MM-DD-hhmmss>.csv'.",
     )


### PR DESCRIPTION
Closes #156

Having a default set for the `--csv-filename` argument was clobbering the values set in users custom configurations.

We will only ever need `--csv-filename** if a user explictly sets it...and now we know that it will take precedence!

Thanks for reporting this @fisher568

**NB* - This is instead of #158 which was stacked on top of #157, not clear why `setup-uv@v9` can't be found as it was
released [two days ago](https://github.com/astral-sh/setup-uv/releases/tag/v9.0.0). I've instead branched off of `main`
and cherry-picked the relevant commit from `ns-rse/156-csv-filename` branch 🪄
