### PR TITLE
refactor - nomenclature

### DIFF
--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -45,7 +45,9 @@ class Parameters:
     load_small: float = Field(default=5.0, title="Maximum length.", ge=0.0)
     max_length: float = Field(default=18.0, title="Maximum length.", ge=0.0)
     max_length_initial_ground_structure: float = Field(
-        default=1.5, title="Threshold for marking a potential member as active in the initial ground structure.", gt=0.0
+        default=1.5,
+        title="Threshold for marking a potential member as active in the initial ground structure.",
+        gt=0.0,
     )
     support_points: npt.NDArray[np.float64] = Field(
         default=np.asarray([[0, 0], [3, 3]]), title="Support Points."
@@ -289,11 +291,11 @@ class Structure:
         Degrees of Freedom
     potential_members : npt.NDArray[np.float64]
         Potential members, with active points indicated.
-    active_members : npt.NDArray[np.float64]
+    active_members : npt.NDArray[np.bool]
         Active members, a subset of `potential_members`, set after solving.
     primal_adaptivity : bool
         Indicator of primal adaptivity.
-    active_load_cases : npt.NDArray[np.float64]
+    load_case_active : npt.NDArray[np.float64]
         Active load cases.
     active_pattern_loads : list[npt.NDArray[np.float64]]
         A subset of `all_patterns` where load cases are active.
@@ -317,8 +319,9 @@ class Structure:
     )
     active_members: npt.NDArray[np.float64] = Field(title="Active members", init=False)
     primal_adaptivity: bool = Field(title="Primal adaptivity", init=False)
-    active_load_cases: npt.NDArray[np.int32] = Field(
-        title="Active load cases", init=False
+    load_case_active: npt.NDArray[np.bool] = Field(
+        title="Indicates whether the corresponding load case is active or not.",
+        init=False,
     )
     active_pattern_loads: list[npt.NDArray[np.float64]] = Field(
         title="Loaded points", init=False
@@ -369,14 +372,14 @@ class Structure:
         self.active_members = self.potential_members[
             self.potential_members[:, 3] == True  # noqa: E712, pylint: disable=singleton-comparison
         ]
-        self.primal_adaptivity, self.active_load_cases = structure.primal_adaptivity(
+        self.primal_adaptivity, self.load_case_active = structure.primal_adaptivity(
             primal_method=self.parameters.primal_method,
             all_patterns_length=len(self.all_patterns),
         )
         self.active_pattern_loads = [
             self.all_patterns[k]
             for k in range(len(self.all_patterns))
-            if self.active_load_cases[k] == 1
+            if self.load_case_active[k]
         ]
 
     def __str__(self) -> str:

--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -44,8 +44,8 @@ class Parameters:
     load_large: float = Field(default=50.0, title="Maximum length.", ge=0.0)
     load_small: float = Field(default=5.0, title="Maximum length.", ge=0.0)
     max_length: float = Field(default=18.0, title="Maximum length.", ge=0.0)
-    active_member_threshold: float = Field(
-        default=1.5, title="Active member threshold", gt=0.0
+    max_length_initial_ground_structure: float = Field(
+        default=1.5, title="Threshold for marking a potential member as active in the initial ground structure.", gt=0.0
     )
     support_points: npt.NDArray[np.float64] = Field(
         default=np.asarray([[0, 0], [3, 3]]), title="Support Points."
@@ -364,7 +364,7 @@ class Structure:
             joint_cost=self.parameters.joint_cost,
             convex=self.convex,
             polygon=self.polygon,
-            active_member_threshold=self.parameters.active_member_threshold,
+            max_length_initial_ground_structure=self.parameters.max_length_initial_ground_structure,
         )
         self.active_members = self.potential_members[
             self.potential_members[:, 3] == True  # noqa: E712, pylint: disable=singleton-comparison

--- a/src/layopt/classes.py
+++ b/src/layopt/classes.py
@@ -295,8 +295,8 @@ class Structure:
         Active members, a subset of `potential_members`, set after solving.
     primal_adaptivity : bool
         Indicator of primal adaptivity.
-    load_case_active : npt.NDArray[np.float64]
-        Active load cases.
+    load_case_active : npt.NDArray[np.bool]
+        Indicates whether the corresponding load case is active or not.
     active_pattern_loads : list[npt.NDArray[np.float64]]
         A subset of `all_patterns` where load cases are active.
     """

--- a/src/layopt/default_config.yaml
+++ b/src/layopt/default_config.yaml
@@ -16,7 +16,7 @@ load_direction: # Load direction
 load_large: 50.0 # Large load
 load_small: 5.0 # Small load
 max_length: 18.0 # Max length
-active_member_threshold: 1.5 # Threshold for marking a potential member as active
+max_length_initial_ground_structure: 1.5 # Threshold for marking a potential member as active in the initial ground structure.
 support_points: # Support points
   - []
 member_area_filtering: 0.001 # Fraction of maximum member area for output threshold

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -231,7 +231,7 @@ def stop_primal_violation_residual(
     c_n: npt.NDArray[np.float64],
     forces: list[npt.NDArray[np.float64]],
     all_patterns: list[npt.NDArray[np.float64]],
-    active_load_cases: npt.NDArray[np.int64],
+    load_case_active: npt.NDArray[np.bool],
     dof: npt.NDArray[np.float64],
 ) -> bool:
     """
@@ -247,7 +247,7 @@ def stop_primal_violation_residual(
         Member forces.
     all_patterns : list[npt.NDArray[np.float64]]
         All load cases.
-    active_load_cases : npt.NDArray[np.int64]
+    load_case_active : npt.NDArray[np.bool]
         For each load case, bool set to ``True`` if active, ``False`` otherwise.
     dof : npt.NDArray[np.float64]
         Degrees of freedom.
@@ -264,7 +264,7 @@ def stop_primal_violation_residual(
 
     # loop through all (active and inactive) pattern load cases
     for k, _ in enumerate(all_patterns):
-        if active_load_cases[k] == 1:
+        if load_case_active[k]:
             continue  # skip active cases
 
         fk_dof = all_patterns[k] * dof
@@ -293,7 +293,7 @@ def stop_primal_violation_residual(
             return True
 
         # Active most violated load pattern
-        active_load_cases[by_violation[0]] = 1
+        load_case_active[by_violation[0]] = True
         violations_added_this_iter = [by_violation[0]]
         by_violation.pop(0)
 
@@ -316,7 +316,7 @@ def stop_primal_violation_residual(
                         distinct = False
                         break
                 if distinct:
-                    active_load_cases[k] = 1
+                    load_case_active[k] = True
                     violations_added_this_iter.append(k)
                     by_violation.remove(k)
                     added_case = True
@@ -342,7 +342,7 @@ def stop_primal_violation_pattern(
     c_n: npt.NDArray[np.float64],
     areas: npt.NDArray[np.float64],
     all_patterns: list[npt.NDArray[np.float64]],
-    active_load_cases: npt.NDArray[np.int64],
+    load_case_active: npt.NDArray[np.bool],
     dof: npt.NDArray[np.float64],
     stress_tensile: float,
     stress_compressive: float,
@@ -361,7 +361,7 @@ def stop_primal_violation_pattern(
         Member areas.
     all_patterns : list[npt.NDArray[np.float64]]
         All load cases.
-    active_load_cases : npt.NDArray[np.int64]
+    load_case_active : npt.NDArray[np.bool]
         For each load case, bool set to True if active, False otherwise.
     dof : npt.NDArray
         Degrees of freedom.
@@ -410,7 +410,7 @@ def stop_primal_violation_pattern(
 
     # loop through all (active and inactive) pattern load cases
     for k, pattern in enumerate(all_patterns):
-        if active_load_cases[k] == 1:
+        if load_case_active[k]:
             continue  # skip active cases
 
         fk_dof_param.value = pattern * dof
@@ -435,7 +435,7 @@ def stop_primal_violation_pattern(
 
         # Add most violated (lowest lambda)
         most_violated_id = by_violation[0]
-        active_load_cases[most_violated_id] = 1
+        load_case_active[most_violated_id] = True
         logger.info(
             f"  Adding most violated pattern {by_violation[0]}: lambda={load_factors[most_violated_id]:.3f}"
         )
@@ -480,7 +480,7 @@ def stop_primal_violation_pattern(
                             distinct = False
                             break
                 if distinct:
-                    active_load_cases[k] = 1
+                    load_case_active[k] = True
                     logger.info(
                         f"  Adding {len(violations_added_this_iter) + 1} distinct pattern {k}: lambda={load_factors[k]:.3f}"
                     )
@@ -542,7 +542,7 @@ def trussopt(
         active_pattern_loads = [
             structure.all_patterns[k]
             for k in range(len(structure.all_patterns))
-            if structure.active_load_cases[k] == 1
+            if structure.load_case_active[k]
         ]
         # Get active members/parts of matrices for current iteration
         active_members = structure.potential_members[
@@ -560,7 +560,7 @@ def trussopt(
         if isinf(vol):
             logger.error("Infeasible problem detected")
             return None
-        n_active = int(np.sum(structure.active_load_cases))
+        n_active = int(np.sum(structure.load_case_active))
         # ns-rse 2026-03-23 : Could this perhaps be debugging?
         logger.info(
             f"Iteration: {itr}, vol: {vol}, mems: {len(active_members)} active load cases:{n_active}/{len(structure.all_patterns)}"
@@ -582,7 +582,7 @@ def trussopt(
             continue  # small vol decrease = member adding close to convergence
 
         # outer loop - adding of pattern load cases based on primal violation
-        # if stopPrimalViolationPattern(nodal_coords, c_n, a, structure.all_patterns, structure.active_load_cases, dof, st, sc):
+        # if stopPrimalViolationPattern(nodal_coords, c_n, a, structure.all_patterns, structure.load_case_active, dof, st, sc):
         #     if numAdded > 0: # only fully terminate when no members violate
         #         continue
         #     else:
@@ -596,7 +596,7 @@ def trussopt(
                     active_members,
                     filter_forces,
                     structure.all_patterns,
-                    structure.active_load_cases,
+                    structure.load_case_active,
                     structure.dof,
                 )
             elif parameters.primal_method == "load_factor":
@@ -606,7 +606,7 @@ def trussopt(
                     active_members,
                     filter_areas,
                     structure.all_patterns,
-                    structure.active_load_cases,
+                    structure.load_case_active,
                     structure.dof,
                     parameters.stress_tensile,
                     parameters.stress_compressive,
@@ -630,7 +630,7 @@ def trussopt(
     solve_end = time.process_time()
     logger.info("Solve took " + str(solve_end - setup_end))
     logger.info(
-        f"Active patterns: {int(np.sum(structure.active_load_cases))}/{len(structure.all_patterns)}"
+        f"Active patterns: {int(np.sum(structure.load_case_active))}/{len(structure.all_patterns)}"
     )
     results = {}
     for filter_level in parameters.filter_levels:
@@ -655,7 +655,7 @@ def trussopt(
             "height": parameters.height,
             "n_load_points": len(parameters.loaded_points),
             "n_patterns_total": len(structure.all_patterns),
-            "n_patterns_active": int(np.sum(structure.active_load_cases)),
+            "n_patterns_active": int(np.sum(structure.load_case_active)),
             "load_large": parameters.load_large,
             "load_small": parameters.load_small,
             "iterations": itr,

--- a/src/layopt/layopt.py
+++ b/src/layopt/layopt.py
@@ -108,7 +108,7 @@ def solve(
     active_members : npt.NDArray[np.float64]
         Active members.
     active_pattern_loads : list[npt.NDArray[np.float64]]
-        Active pattern loads.
+        A subset of 'all_patterns' where load cases are active.
 
     Returns
     -------

--- a/src/layopt/structure.py
+++ b/src/layopt/structure.py
@@ -186,7 +186,7 @@ def calc_potential_members(
     joint_cost: float,
     convex: bool,
     polygon: Polygon,
-    active_member_threshold: float = 1.5,
+    max_length_initial_ground_structure: float = 1.5,
 ) -> npt.NDArray[np.float64]:
     """
     Create the ground structure.
@@ -203,8 +203,8 @@ def calc_potential_members(
         Whether the structure is convex.
     polygon : Polygon
         Bounding box for the structure.
-    active_member_threshold : float
-        Threshold for marking a potential member as active.
+    max_length_initial_ground_structure : float
+        Threshold for marking a potential member as active in the initial ground structure.
 
     Returns
     -------
@@ -223,7 +223,7 @@ def calc_potential_members(
             seg = [] if convex else LineString([nodes[i], nodes[j]])
             if convex or polygon.contains(seg) or polygon.boundary.contains(seg):
                 # Mark as active
-                if length <= active_member_threshold:
+                if length <= max_length_initial_ground_structure:
                     potential_members.append([i, j, length, True])
                 else:
                     potential_members.append([i, j, length, False])

--- a/src/layopt/structure.py
+++ b/src/layopt/structure.py
@@ -247,10 +247,10 @@ def primal_adaptivity(
     Returns
     -------
     tuple[bool, npt.NDArray[np.bool]]
-        A tuple of a boolean for ``primal_method`` and the associated ``active_load_cases``.
+        A tuple of a boolean for ``primal_method`` and the associated ``load_case_active``.
     """
     if primal_method in {"residual", "load_factor"}:
-        active_load_cases = np.zeros(all_patterns_length, dtype=np.bool)
-        active_load_cases[0] = 1  # Base case = all large loads
-        return (True, active_load_cases)
+        load_case_active = np.zeros(all_patterns_length, dtype=np.bool)
+        load_case_active[0] = 1  # Base case = all large loads
+        return (True, load_case_active)
     return (False, np.ones(all_patterns_length, dtype=np.bool))

--- a/src/layopt/validation.py
+++ b/src/layopt/validation.py
@@ -114,10 +114,10 @@ LAYOPT_CONFIG_SCHEMA = Schema(
             And(float, lambda n: n >= 0.0),
             error="Invalid value in config for 'max_length', valid values are >= 0.0.",
         ),
-        "active_member_threshold": And(
+        "max_length_initial_ground_structure": And(
             float,
             lambda n: n > 0,
-            error="Invalid value in config for 'active_member_threshold', this should be a float > 0.",
+            error="Invalid value in config for 'max_length_initial_ground_structure', this should be a float > 0.",
         ),
         "support_points": And(
             np.ndarray,

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -212,7 +212,7 @@ def test_parameters_exceptions(config: ValidationError) -> None:
                 "potential_members": np.empty((0, 4)),
                 "active_members": np.empty((0, 4), dtype=np.float64),
                 "primal_adaptivity": True,
-                "active_load_cases": np.asarray([0]),
+                "load_case_active": np.asarray([False], dtype=np.bool),
                 "active_pattern_loads": np.asarray([]),
             },
             id="1x1",
@@ -235,7 +235,7 @@ def test_parameters_exceptions(config: ValidationError) -> None:
                 "potential_members": np.empty((0, 4)),
                 "active_members": np.empty((0, 4), dtype=np.float64),
                 "primal_adaptivity": True,
-                "active_load_cases": np.asarray([0]),
+                "load_case_active": np.asarray([False], dtype=np.bool),
                 "active_pattern_loads": np.asarray([]),
             },
             id="2x2",
@@ -258,7 +258,7 @@ def test_parameters_exceptions(config: ValidationError) -> None:
                 "potential_members": np.empty((0, 4)),
                 "active_members": np.empty((0, 4), dtype=np.float64),
                 "primal_adaptivity": True,
-                "active_load_cases": np.asarray([0]),
+                "load_case_active": np.asarray([False], dtype=np.bool),
                 "active_pattern_loads": np.asarray([]),
             },
             id="18x4 spanning",
@@ -329,7 +329,7 @@ def test_structure_post_init(
     )
     assert structure.primal_adaptivity == expected_attributes["primal_adaptivity"]
     np.testing.assert_array_equal(
-        structure.active_load_cases, expected_attributes["active_load_cases"]
+        structure.load_case_active, expected_attributes["load_case_active"]
     )
     np.testing.assert_array_equal(
         structure.active_pattern_loads, expected_attributes["active_pattern_loads"]

--- a/tests/test_layopt.py
+++ b/tests/test_layopt.py
@@ -325,7 +325,7 @@ def test_member_area_filtering(
 @pytest.mark.parametrize(
     (
         "all_patterns",
-        "active_load_cases",
+        "load_case_active",
         "areas",
         "stress_tensile",
         "stress_compressive",
@@ -412,7 +412,7 @@ def test_member_area_filtering(
                     ]
                 ),
             ],  # all_patterns
-            np.asarray([True, True, True, True]),  # active_load_cases
+            np.asarray([True, True, True, True]),  # load_case_active
             np.ones(10),  # areas
             1,  # stress_tensile
             1,  # stress_compressive
@@ -451,7 +451,7 @@ def test_member_area_filtering(
                     ]
                 ),
             ],  # all_patterns
-            np.asarray([True, False]),  # active_load_cases
+            np.asarray([True, False]),  # load_case_active
             np.ones(10),  # areas
             1,  # stress_tensile
             1,  # stress_compressive
@@ -468,7 +468,7 @@ def test_stop_primal_violation(
     nodes: npt.NDArray[np.float64],
     active_members: npt.NDArray[np.float64],
     all_patterns: npt.NDArray[np.float64],
-    active_load_cases: npt.NDArray[np.float64],
+    load_case_active: npt.NDArray[np.float64],
     areas: npt.NDArray[np.float64],
     stress_tensile: int,
     stress_compressive: int,
@@ -482,14 +482,14 @@ def test_stop_primal_violation(
         active_members,
         areas,
         all_patterns,
-        active_load_cases,
+        load_case_active,
         dof,
         stress_tensile,
         stress_compressive,
         solver,
     )
     assert actual_converge == expected_converge
-    assert np.all(active_load_cases) is np.bool_(
+    assert np.all(load_case_active) is np.bool_(
         True
     )  # checks that violating inactive load cases added
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -525,21 +525,29 @@ def test_calc_potential_members(
         "primal_method",
         "all_patterns_length",
         "expected_primal_method",
-        "expected_active_load_cases",
+        "expected_load_case_active",
     ),
     [
         pytest.param(
-            "residual", 4, True, np.asarray([1, 0, 0, 0]), id="residual of length 4"
+            "residual",
+            4,
+            True,
+            np.asarray([True, False, False, False], dtype=np.bool),
+            id="residual of length 4",
         ),
         pytest.param(
             "load_factor",
             4,
             True,
-            np.asarray([1, 0, 0, 0]),
+            np.asarray([True, False, False, False], dtype=np.bool),
             id="load_factor of length 4",
         ),
         pytest.param(
-            "other", 4, False, np.asarray([1, 1, 1, 1]), id="other of length 4"
+            "other",
+            4,
+            False,
+            np.asarray([True, True, True, True], dtype=np.bool),
+            id="other of length 4",
         ),
     ],
 )
@@ -547,14 +555,14 @@ def test_primal_adaptivity(
     primal_method: str,
     all_patterns_length: int,
     expected_primal_method: bool,
-    expected_active_load_cases: npt.NDArray[np.int32],
+    expected_load_case_active: npt.NDArray[np.bool],
 ) -> None:
     """Test for ``structure.primal_adaptivity()``."""
-    primal_method_result, active_load_cases = structure.primal_adaptivity(
+    primal_method_result, load_case_active = structure.primal_adaptivity(
         primal_method=primal_method, all_patterns_length=all_patterns_length
     )
     assert primal_method_result == expected_primal_method
     np.testing.assert_array_equal(
-        active_load_cases,
-        expected_active_load_cases,
+        load_case_active,
+        expected_load_case_active,
     )


### PR DESCRIPTION
Closes #151

Addresses the inconsistent nomenclature discussed in #151 and improves the type hints and docstrings for variables.

- `active_member_threshold` > `max_length_initial_ground_structure`: float
- `active_load_cases` > `load_case_active`: npt.NDArray[np.bool]

---

Before submitting a Pull Request please check the following.

- [ ] I have a MOSEK license.
- [ ] Existing tests pass.
- [ ] Documentation has been updated and builds.
- [ ] Pre-commit checks pass.
- [ ] New functions/methods have typehints and docstrings.
- [ ] New functions/methods have tests which check the intended behaviour is correct.