### PR TITLE
fix: log-level error by removing all default args

### DIFF
--- a/src/layopt/entry_point.py
+++ b/src/layopt/entry_point.py
@@ -207,7 +207,6 @@ def layopt_parser() -> arg.ArgumentParser:
         dest="output_dir",
         type=Path,
         required=False,
-        default="./",
         help="Path to where the YAML file should be saved (default './' the current directory).",
     )
     create_config_parser.add_argument(
@@ -215,7 +214,6 @@ def layopt_parser() -> arg.ArgumentParser:
         "--config",
         dest="config",
         type=str,
-        default="default",
         help="Configuration to use, currently only 'default' is supported.",
     )
     create_config_parser.set_defaults(func=write_config)

--- a/src/layopt/run_modules.py
+++ b/src/layopt/run_modules.py
@@ -49,7 +49,7 @@ def _log_setup(_config: dict[str, Any]) -> None:
     logger.info(f"Cores for parallel processing       : {_config['cores']}")
 
 
-def _set_logging(log_level: str) -> None:
+def _set_logging(log_level: str = "info") -> None:
     """
     Set up loguru logging.
 
@@ -114,10 +114,10 @@ def optimise(args: argparse.Namespace | None = None) -> None:
     args : argparse.Namespace | None
         Command line arguments for modifying configuration.
     """
-    _set_logging(log_level=args.log_level)  # type: ignore[union-attr]
+    if args.log_level:  # type: ignore[union-attr]
+        _set_logging(log_level=args.log_level)  # type: ignore[union-attr]
     logger.debug(f"\n{pformat(vars(args))}\n")
     _config = _parse_configuration(args)
-    _set_logging(log_level=_config.log_level)
     # Ensure filter_levels is a list and includes 1.0
     filter_levels = (
         np.asarray([1.0])

--- a/src/layopt/run_modules.py
+++ b/src/layopt/run_modules.py
@@ -114,28 +114,41 @@ def optimise(args: argparse.Namespace | None = None) -> None:
     args : argparse.Namespace | None
         Command line arguments for modifying configuration.
     """
+    # Set conservative log level to start with, this will be changed if args.log_level exists and then set to whatever
+    # the value is after reconciling args.log_level with that in the configuration file.
+    _set_logging(log_level="info")
+    # If user has explicitly requested a given log-level on the command line we set that (likely use case is for
+    # debugging)
     if args.log_level:  # type: ignore[union-attr]
         _set_logging(log_level=args.log_level)  # type: ignore[union-attr]
+    # Show what the command line arguments are
     logger.debug(f"\n{pformat(vars(args))}\n")
-    _config = _parse_configuration(args)
+    parameters = _parse_configuration(args)
     # Ensure filter_levels is a list and includes 1.0
     filter_levels = (
         np.asarray([1.0])
-        if len(_config.filter_levels) == 0
-        else np.asarray(_config.filter_levels)
+        if len(parameters.filter_levels) == 0
+        else np.asarray(parameters.filter_levels)
     )
     # ns-rse 2026-04-30 : if 1.0 isn't in filter_levels we add it so we always have unfiltered results
     if 1.0 not in filter_levels:
         # if 1.0 not in filter_levels:
         filter_levels = np.append(filter_levels, 1.0)
-    _, _, results_df = layopt.trussopt(parameters=_config)  # type: ignore[misc]
-    # Transpose and tidy data frame and write results and configuration to disk
-    results_df = results_df.T.reset_index(drop=True)
-    results_df = results_df.sort_values(["filter_level"])
-    results_df.to_csv(Path(_config.output_dir) / _config.csv_filename, index=False)
-    io.write_config(_config)
-    logger.info(f"Results saved to {Path(_config.output_dir) / _config.csv_filename}")
-    completion_message(_config=_config)
+    try:
+        _, _, results_df = layopt.trussopt(parameters=parameters)  # type: ignore[misc]
+        # Transpose and tidy data frame and write results and configuration to disk
+        results_df = results_df.T.reset_index(drop=True)
+        results_df = results_df.sort_values(["filter_level"])
+        results_df.to_csv(
+            Path(parameters.output_dir) / parameters.csv_filename, index=False
+        )
+        io.write_config(parameters)
+        logger.info(
+            f"Results saved to {Path(parameters.output_dir) / parameters.csv_filename}"
+        )
+        completion_message(_config=parameters)
+    except:  # noqa: E722, pylint: disable=bare-except
+        logger.error("Optimisation failed, please refer to earlier log messages.")
 
 
 def completion_message(_config: dict[str, Any] | classes.Parameters) -> None:

--- a/tests/resources/config/debug_config.yaml
+++ b/tests/resources/config/debug_config.yaml
@@ -1,0 +1,42 @@
+# For more information on configuration and how to use it:
+# https://icair-sheffield.github.io/LayOpt/
+base_dir: .
+output_dir: output
+log_level: debug
+cores: 2
+width: 3
+height: 3
+steps: 1.0
+stress_tensile: 1.0
+stress_compressive: 1.0
+joint_cost: 0.0
+loaded_points:
+  -   - 1
+      - 0
+  -   - 2
+      - 0
+load_direction:
+  - 0.0
+  - -1.0
+load_large: 50.0
+load_small: 5.0
+max_length: 18.0
+active_member_threshold: 1.5
+support_points:
+  -   - 0
+      - 0
+  -   - 3
+      - 3
+member_area_filtering: 0.001
+cvxpy:
+  solver: clarabel
+filter_levels:
+  - 1.0
+primal_method: load_factor
+problem_name: ''
+csv_filename: results.csv
+notes: ''
+plotting:
+  run: false
+  bar_thickness: 0.3
+  dpi: 1200

--- a/tests/resources/config/info_config.yaml
+++ b/tests/resources/config/info_config.yaml
@@ -1,0 +1,42 @@
+# For more information on configuration and how to use it:
+# https://icair-sheffield.github.io/LayOpt/
+base_dir: .
+output_dir: output
+log_level: info
+cores: 2
+width: 3
+height: 3
+steps: 1.0
+stress_tensile: 1.0
+stress_compressive: 1.0
+joint_cost: 0.0
+loaded_points:
+  -   - 1
+      - 0
+  -   - 2
+      - 0
+load_direction:
+  - 0.0
+  - -1.0
+load_large: 50.0
+load_small: 5.0
+max_length: 18.0
+active_member_threshold: 1.5
+support_points:
+  -   - 0
+      - 0
+  -   - 3
+      - 3
+member_area_filtering: 0.001
+cvxpy:
+  solver: clarabel
+filter_levels:
+  - 1.0
+primal_method: load_factor
+problem_name: ''
+csv_filename: results.csv
+notes: ''
+plotting:
+  run: false
+  bar_thickness: 0.3
+  dpi: 1200

--- a/tests/test_run_modules.py
+++ b/tests/test_run_modules.py
@@ -69,6 +69,82 @@ def test_optimise(
     )
 
 
+@pytest.mark.skipif(
+    GITHUB_ACTIONS,
+    reason="mosek library requires license so test will always fail in continuous integration",
+)
+@pytest.mark.parametrize(
+    ("args", "log_string"),
+    [
+        pytest.param(
+            argparse.Namespace(
+                config_file=None,
+                width=1,
+                height=1,
+                log_level="info",
+                func="optimise",
+                module="layopt",
+            ),
+            "INFO",
+            id="no config; log-level info",
+        ),
+        pytest.param(
+            argparse.Namespace(
+                config_file=None,
+                width=1,
+                height=1,
+                log_level="debug",
+                func="optimise",
+                module="layopt",
+            ),
+            "DEBUG",
+            id="no config; log-level debug",
+        ),
+        pytest.param(
+            argparse.Namespace(
+                config_file=Path("tests/resources/config/info_config.yaml"),
+                width=1,
+                height=1,
+                log_level="error",
+                func="optimise",
+                module="layopt",
+            ),
+            "ERROR",
+            id="config info; log-level error",
+        ),
+        pytest.param(
+            argparse.Namespace(
+                config_file=Path("tests/resources/config/debug_config.yaml"),
+                width=1,
+                height=1,
+                log_level="info",
+                func="optimise",
+                module="layopt",
+            ),
+            "INFO",
+            id="config debug; log-level info",
+        ),
+    ],
+)
+def test_optimise_different_log_levels(
+    args: argparse.Namespace, log_string: str, tmp_path: Path, capsys
+) -> None:
+    """
+    Test parsing of arguments from both configuration file and from the command line.
+
+    This is a slightly indirect test because it is 'run_modules._parse_configuration()' and in turn
+    'config.reconcile_config_args()' that do the leg work here but this is still a useful test as it emulates what
+    happens when the entry point is called.
+
+    Note we do not use the Pytest 'caplog' because it defaults to the standard library's 'logging' module which doesn't
+    play well with 'loguru'. Instead we capture logging via 'capsys'.
+    """
+    args.output_dir = tmp_path
+    run_modules.optimise(args=args)
+    output = capsys.readouterr().err
+    assert log_string in output
+
+
 @pytest.mark.parametrize(
     ("_config", "check"),
     [


### PR DESCRIPTION
Closes #165

- No more `default = <value>` in arguments. That way if no arguments are given `args` will be empty, if users _do_
  specify arguments then only those they actually specify will be present.
- Because we have `logger.debug()` statements in `run_modules.parse_config()` we have two calls to
  `run_modules._set_logging()` in `run_modules.optimise()`, the first ensures that we get output from parsing the
  configuration file if we want it, the second then sets log level again to whatever is specified in the configuration
  file. Previously the first call was always made with log-level as `info` (the default for the `--log-level` argument) or
  if the user actually specified this option whatever that value was. Instead we now check to see if it is a value and set
  it appropriately, if not we have now set a default value to `run_modules._setup_logging(log_level="info")` so that we
  always get `info` log level out of `run_modules.parse_config()`. There is perhaps a case for setting this default to
`debug` but that would mean users always see the parsing debugging which probably isn't desirable.
- switches from `_config` to `parameters` in `run_modules.optimise()` after reconciling configuration options as this is
  what is returned by `_parse_configuration()`
- adds a `try: ... except:` because if optimisation fails with "infeasible" it only logs an error rather than raising an
  exception (we should probably look to raise an exception so we can handle this correctly).
- adds tests with different sets of configuration files and command line options and checks that the   appropriate logs
  are made.


---

Before submitting a Pull Request please check the following.

- [X] I have a MOSEK license.
- [X] Existing tests pass.
- [ ] ~Documentation has been updated and builds.~
- [X] Pre-commit checks pass.
- [ ] ~New functions/methods have typehints and docstrings.~
- [ ] ~New functions/methods have tests which check the intended behaviour is correct.~